### PR TITLE
fix: skip maturin build for Python lint/format scripts

### DIFF
--- a/bin/check-py
+++ b/bin/check-py
@@ -3,10 +3,10 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 echo "Running ruff..."
-uv run ruff check .
-uv run ruff format --check .
+uv run --only-group dev ruff check .
+uv run --only-group dev ruff format --check .
 
 echo "Running ty..."
-uv run ty check
+uv run --only-group dev ty check
 
 echo "Python checks passed!"

--- a/bin/format-py
+++ b/bin/format-py
@@ -3,7 +3,7 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 echo "Formatting Python..."
-uv run ruff check --fix .
-uv run ruff format .
+uv run --only-group dev ruff check --fix .
+uv run --only-group dev ruff format .
 
 echo "Python formatting complete!"


### PR DESCRIPTION
## Summary

- Use `uv run --only-group dev` in `bin/check-py` and `bin/format-py` so ruff/ty run without triggering a full maturin (Rust→PyO3) build
- CI was rebuilding the Python extension from scratch every run because `.venv` isn't cached and `uv run` syncs the full project by default


🤖 Generated with [Claude Code](https://claude.com/claude-code)