### PR TITLE
feat: handle V1FlowRunList wrapper from backend

### DIFF
--- a/src/ascend_tools/ascend-tools-cli/src/cli.rs
+++ b/src/ascend_tools/ascend-tools-cli/src/cli.rs
@@ -350,7 +350,11 @@ fn handle_flow(
             filters.until = until;
             filters.offset = offset;
             filters.limit = limit;
-            let runs = client.list_flow_runs(&runtime, filters)?;
+            let result = client.list_flow_runs(&runtime, filters)?;
+            if result.truncated {
+                eprintln!("Warning: results may be incomplete (server-side limit reached)");
+            }
+            let runs = &result.items;
             match output {
                 OutputMode::Json => print_json(&runs)?,
                 OutputMode::Text => {

--- a/src/ascend_tools/ascend-tools-core/src/client.rs
+++ b/src/ascend_tools/ascend-tools-core/src/client.rs
@@ -5,7 +5,9 @@ use ureq::Agent;
 use crate::auth::Auth;
 use crate::config::Config;
 use crate::error::{Error, JsonResultExt, Result, UreqResultExt};
-use crate::models::{Flow, FlowRun, FlowRunFilters, FlowRunTrigger, Runtime, RuntimeFilters};
+use crate::models::{
+    Flow, FlowRun, FlowRunFilters, FlowRunList, FlowRunTrigger, Runtime, RuntimeFilters,
+};
 
 const PATH_SEGMENT: &AsciiSet = &CONTROLS.add(b' ').add(b'#').add(b'%').add(b'/').add(b'?');
 
@@ -148,7 +150,7 @@ impl AscendClient {
         &self,
         runtime_uuid: &str,
         filters: FlowRunFilters,
-    ) -> Result<Vec<FlowRun>> {
+    ) -> Result<FlowRunList> {
         let mut qs = QueryString::new();
         qs.push("runtime_uuid", runtime_uuid);
         qs.push_opt("status", filters.status.as_deref());

--- a/src/ascend_tools/ascend-tools-core/src/models.rs
+++ b/src/ascend_tools/ascend-tools-core/src/models.rs
@@ -32,6 +32,14 @@ pub struct FlowRun {
     pub error: Option<serde_json::Value>,
 }
 
+/// Wrapper returned by the list flow runs endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlowRunList {
+    pub items: Vec<FlowRun>,
+    #[serde(default)]
+    pub truncated: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FlowRunTrigger {
     pub event_uuid: String,

--- a/src/ascend_tools/ascend-tools-core/tests/client_http.rs
+++ b/src/ascend_tools/ascend-tools-core/tests/client_http.rs
@@ -122,7 +122,7 @@ fn encodes_query_values_and_path_segments() {
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body("[]")
+        .with_body(r#"{"items":[],"truncated":false}"#)
         .expect(1)
         .create();
 
@@ -155,8 +155,9 @@ fn encodes_query_values_and_path_segments() {
     filters.until = Some("2026-01-02T00:00:00Z".to_string());
     filters.offset = Some(10);
     filters.limit = Some(50);
-    let runs = client.list_flow_runs("rt /?#", filters).unwrap();
-    assert!(runs.is_empty());
+    let result = client.list_flow_runs("rt /?#", filters).unwrap();
+    assert!(result.items.is_empty());
+    assert!(!result.truncated);
 
     let run = client.get_flow_run("rt /?#", "fr/with space#hash").unwrap();
     assert_eq!(run.name, "fr/with space#hash");

--- a/src/ascend_tools/ascend-tools-mcp/src/server.rs
+++ b/src/ascend_tools/ascend-tools-mcp/src/server.rs
@@ -372,15 +372,18 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
-                serde_json::json!([{
-                    "name": "fr-1",
-                    "flow": "sales",
-                    "build_uuid": "b-1",
-                    "runtime_uuid": "rt-1",
-                    "status": "running",
-                    "created_at": "2026-01-01T00:00:00Z",
-                    "error": null
-                }])
+                serde_json::json!({
+                    "items": [{
+                        "name": "fr-1",
+                        "flow": "sales",
+                        "build_uuid": "b-1",
+                        "runtime_uuid": "rt-1",
+                        "status": "running",
+                        "created_at": "2026-01-01T00:00:00Z",
+                        "error": null
+                    }],
+                    "truncated": false
+                })
                 .to_string(),
             )
             .expect(1)
@@ -478,7 +481,9 @@ mod tests {
             }))
             .await
             .unwrap();
-        assert_eq!(tool_result_json(runs)[0]["name"], "fr-1");
+        let runs_json = tool_result_json(runs);
+        assert_eq!(runs_json["items"][0]["name"], "fr-1");
+        assert_eq!(runs_json["truncated"], false);
 
         let run = mcp
             .get_flow_run(Parameters(GetFlowRunParams {

--- a/src/ascend_tools/ascend-tools-py/src/lib.rs
+++ b/src/ascend_tools/ascend-tools-py/src/lib.rs
@@ -117,7 +117,7 @@ impl Client {
         offset: Option<u64>,
         limit: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
-        let runs = py
+        let result = py
             .detach(|| {
                 let mut filters = models::FlowRunFilters::default();
                 filters.status = status.map(String::from);
@@ -129,7 +129,7 @@ impl Client {
                 self.inner.list_flow_runs(runtime_uuid, filters)
             })
             .map_err(to_py_err)?;
-        to_python(py, &runs)
+        to_python(py, &result)
     }
 
     #[pyo3(signature = (*, runtime_uuid, name))]

--- a/src/ascend_tools/core.pyi
+++ b/src/ascend_tools/core.pyi
@@ -57,8 +57,12 @@ class Client:
         until: str | None = None,
         offset: int | None = None,
         limit: int | None = None,
-    ) -> list[dict[str, Any]]:
-        """List flow runs, optionally filtered by status, flow name, or time range."""
+    ) -> dict[str, Any]:
+        """List flow runs, optionally filtered by status, flow name, or time range.
+
+        Returns ``{"items": [...], "truncated": bool}``. The ``truncated`` flag
+        indicates the server-side row limit was reached and results may be incomplete.
+        """
         ...
     def get_flow_run(self, *, runtime_uuid: str, name: str) -> dict[str, Any]:
         """Get a flow run by name."""

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -182,8 +182,13 @@ def main():
 
     print("=== flow runs (before trigger) ===")
 
-    runs_before = client.list_flow_runs(runtime_uuid=runtime_uuid, flow_name=flow_name)
-    check(isinstance(runs_before, list), "list_flow_runs returns list")
+    runs_before_result = client.list_flow_runs(
+        runtime_uuid=runtime_uuid, flow_name=flow_name
+    )
+    check(isinstance(runs_before_result, dict), "list_flow_runs returns dict")
+    check("items" in runs_before_result, "list_flow_runs has 'items' key")
+    check("truncated" in runs_before_result, "list_flow_runs has 'truncated' key")
+    runs_before = runs_before_result["items"]
     runs_before_count = len(runs_before)
     check(True, f"list_flow_runs returned {runs_before_count} run(s) before trigger")
 
@@ -216,7 +221,7 @@ def main():
     # test pagination
     limited = client.list_flow_runs(
         runtime_uuid=runtime_uuid, flow_name=flow_name, limit=1
-    )
+    )["items"]
     check(
         len(limited) <= 1,
         "list_flow_runs(limit=1) returns at most 1",
@@ -226,7 +231,7 @@ def main():
     if runs_before_count > 1:
         offset_runs = client.list_flow_runs(
             runtime_uuid=runtime_uuid, flow_name=flow_name, offset=1, limit=1
-        )
+        )["items"]
         check(
             len(offset_runs) <= 1, "list_flow_runs(offset=1, limit=1) returns at most 1"
         )
@@ -263,7 +268,7 @@ def main():
         time.sleep(delay)
         runs_after = client.list_flow_runs(
             runtime_uuid=runtime_uuid, flow_name=flow_name
-        )
+        )["items"]
         runs_after_count = len(runs_after)
         if runs_after_count > runs_before_count:
             break
@@ -291,10 +296,13 @@ def main():
     print("=== status filter ===")
 
     for status in ("pending", "running", "succeeded", "failed"):
-        by_status = client.list_flow_runs(runtime_uuid=runtime_uuid, status=status)
+        by_status_result = client.list_flow_runs(
+            runtime_uuid=runtime_uuid, status=status
+        )
+        by_status = by_status_result["items"]
         check(
             isinstance(by_status, list),
-            f"list_flow_runs(status={status!r}) returns list",
+            f"list_flow_runs(status={status!r}) returns list items",
         )
         if by_status:
             wrong = [r for r in by_status if r["status"] != status]


### PR DESCRIPTION
Depends on https://github.com/ascend-io/ascend-backend/pull/1240

## Summary

- Add `FlowRunList` model (`items` + `truncated`) to match backend's new `list_flow_runs` response shape
- SDK client `list_flow_runs` returns `FlowRunList` instead of `Vec<FlowRun>`
- MCP server preserves `truncated` flag for AI clients
- CLI warns on stderr when results are truncated
- Python SDK returns wrapper dict with `truncated` metadata
- All test mocks updated to new response format

🤖 Generated with [Claude Code](https://claude.com/claude-code)