### PR TITLE
feat: crates.io release CI and versioned inter-crate deps

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -1,0 +1,39 @@
+name: Release Rust
+
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v1.0.0)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    environment: crates-io
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: crates-io-${{ hashFiles('Cargo.lock') }}
+          restore-keys: crates-io-
+      - name: Publish crates
+        run: |
+          cargo publish -p ascend-tools-core
+          cargo publish -p ascend-tools-tui
+          cargo publish -p ascend-tools-mcp
+          cargo publish -p ascend-tools-cli

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -87,6 +87,15 @@ for f in "${TOML_FILES[@]}"; do
   echo "  updated $f"
 done
 
+# Update inter-crate dependency versions
+WORKSPACE_CRATES=(ascend-tools-core ascend-tools-tui ascend-tools-mcp ascend-tools-cli)
+for f in "${TOML_FILES[@]}"; do
+  for crate in "${WORKSPACE_CRATES[@]}"; do
+    sed -i '' "s/$crate = { version = \"$CURRENT\"/$crate = { version = \"$NEW\"/" "$f"
+  done
+done
+echo "  updated inter-crate dependency versions"
+
 # ---------- update package.json ----------
 
 sed -i '' "s/\"version\": \"$CURRENT\"/\"version\": \"$NEW\"/" "$JS_PACKAGE_JSON"

--- a/bin/release
+++ b/bin/release
@@ -14,10 +14,10 @@ usage() {
   echo "  - Working tree is clean (override with --allow-dirty)"
   echo "  - bin/check passes"
   echo "  - Git tag does not already exist on GitHub"
-  echo "  - Package version does not already exist on PyPI"
+  echo "  - Package version does not already exist on PyPI or crates.io"
   echo ""
   echo "Options:"
-  echo "  --force        Skip GitHub tag, PyPI, and origin/main checks"
+  echo "  --force        Skip GitHub tag, PyPI, crates.io, and origin/main checks"
   echo "  --allow-dirty  Skip clean working tree check"
   exit "${1:-0}"
 }
@@ -106,6 +106,19 @@ if [ "$FORCE" = false ]; then
   echo "  ascend-tools $VERSION does not exist on PyPI"
 else
   echo "  skipping PyPI check (--force)"
+fi
+
+# ---------- check crates.io ----------
+
+if [ "$FORCE" = false ]; then
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/ascend-tools-core/$VERSION")
+  if [ "$HTTP_STATUS" = "200" ]; then
+    echo "ERROR: ascend-tools-core $VERSION already exists on crates.io. Use --force to override." >&2
+    exit 1
+  fi
+  echo "  ascend-tools-core $VERSION does not exist on crates.io"
+else
+  echo "  skipping crates.io check (--force)"
 fi
 
 # ---------- tag and push ----------

--- a/crates/ascend-tools-cli/Cargo.toml
+++ b/crates/ascend-tools-cli/Cargo.toml
@@ -19,9 +19,9 @@ name = "ascend-tools"
 path = "src/main.rs"
 
 [dependencies]
-ascend-tools-core = { path = "../ascend-tools-core" }
-ascend-tools-mcp = { path = "../ascend-tools-mcp" }
-ascend-tools-tui = { path = "../ascend-tools-tui" }
+ascend-tools-core = { version = "1.0.0", path = "../ascend-tools-core" }
+ascend-tools-mcp = { version = "1.0.0", path = "../ascend-tools-mcp" }
+ascend-tools-tui = { version = "1.0.0", path = "../ascend-tools-tui" }
 clap = { version = "4.5", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/ascend-tools-mcp/Cargo.toml
+++ b/crates/ascend-tools-mcp/Cargo.toml
@@ -15,7 +15,7 @@ name = "ascend_tools_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-ascend-tools-core = { path = "../ascend-tools-core" }
+ascend-tools-core = { version = "1.0.0", path = "../ascend-tools-core" }
 rmcp = { version = "0.17", features = [
     "server",
     "macros",

--- a/crates/ascend-tools-tui/Cargo.toml
+++ b/crates/ascend-tools-tui/Cargo.toml
@@ -15,7 +15,7 @@ name = "ascend_tools_tui"
 path = "src/lib.rs"
 
 [dependencies]
-ascend-tools-core = { path = "../ascend-tools-core" }
+ascend-tools-core = { version = "1.0.0", path = "../ascend-tools-core" }
 anyhow = "1"
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 crossterm = "0.29"


### PR DESCRIPTION
## Summary
- Add `release-rust.yml` workflow to publish 4 crates to crates.io on tag push (OIDC trusted publishing, matching PyPI/npm pattern)
- Add version specifiers to inter-crate path dependencies (required by crates.io)
- Update `bin/release` to pre-flight check crates.io
- Update `bin/bump-version` to bump inter-crate dependency versions

All 4 crates manually published as v1.0.0: `ascend-tools-core`, `ascend-tools-tui`, `ascend-tools-mcp`, `ascend-tools-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)