### PR TITLE
fix: add NPM_TOKEN for npm publish auth

### DIFF
--- a/.github/workflows/release-javascript.yml
+++ b/.github/workflows/release-javascript.yml
@@ -78,4 +78,6 @@ jobs:
           path: crates/ascend-tools-js
           merge-multiple: true
       - working-directory: crates/ascend-tools-js
-        run: npm publish --access public
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- npm doesn't support OIDC trusted publishing — requires an actual access token
- Add `NPM_TOKEN` from environment secret for auth
- Add `--provenance` flag for signed build attestation (uses the `id-token: write` permission)

**Setup**: Add an `NPM_TOKEN` secret to the `npm` GitHub environment with a granular npm access token scoped to `ascend-tools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)