### PR TITLE
fix: remove registry-url to allow npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-javascript.yml
+++ b/.github/workflows/release-javascript.yml
@@ -72,7 +72,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
       - uses: actions/download-artifact@v4
         with:
           path: crates/ascend-tools-js


### PR DESCRIPTION
## Summary

- Remove `registry-url` from `actions/setup-node` in the publish job
- `registry-url` creates an `.npmrc` referencing `NODE_AUTH_TOKEN`, which blocks npm's native OIDC auto-detection
- Without it, `npm publish` detects the OIDC environment and authenticates via trusted publishing automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)