### PR TITLE
fix: Node.js 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -15,7 +15,7 @@ runs:
         python-version: "3.13"
     - uses: actions/setup-node@v4
       with:
-        node-version: "22"
+        node-version: "24"
     - uses: actions/cache@v4
       with:
         path: |

--- a/.github/workflows/release-javascript.yml
+++ b/.github/workflows/release-javascript.yml
@@ -34,7 +34,7 @@ jobs:
           ref: ${{ github.event.inputs.tag || github.ref }}
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
       - uses: actions/cache@v4
         with:
           path: |
@@ -71,7 +71,7 @@ jobs:
           ref: ${{ github.event.inputs.tag || github.ref }}
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - uses: actions/download-artifact@v4
         with:

--- a/bin/setup
+++ b/bin/setup
@@ -41,9 +41,9 @@ echo "  uv $(uv --version | awk '{print $2}')"
 if ! command -v node &>/dev/null; then
     echo ""
     echo "ERROR: node is not on PATH."
-    echo "Install Node.js 22+ via fnm, nvm, or https://nodejs.org"
-    echo "  fnm:  fnm install 22 && fnm use 22"
-    echo "  nvm:  nvm install 22 && nvm use 22"
+    echo "Install Node.js 24+ via fnm, nvm, or https://nodejs.org"
+    echo "  fnm:  fnm install 24 && fnm use 24"
+    echo "  nvm:  nvm install 24 && nvm use 24"
     echo "Then re-run bin/setup."
     exit 1
 fi

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,7 @@ Guide for contributors working on ascend-tools.
 
 - **Rust** stable toolchain (1.85+, edition 2024)
 - **Python** 3.11+ (for PyO3 bindings and linting)
-- **Node.js** 22+ (for napi-rs bindings and JS tests)
+- **Node.js** 24+ (for napi-rs bindings and JS tests)
 - **uv** (Python package manager)
 
 ## Setup


### PR DESCRIPTION
## Summary

- Bump Node.js 22 → 24 everywhere (release workflow, setup action, bin/setup, docs) — Node 22's npm doesn't support OIDC trusted publishing (requires npm >= 11.5.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)