### PR TITLE
feat(otto): validation surface for streaming, thinking, and probes

### DIFF
--- a/crates/ascend-tools-cli/src/otto.rs
+++ b/crates/ascend-tools-cli/src/otto.rs
@@ -30,6 +30,7 @@ pub(crate) enum ThinkingLevelArg {
     Medium,
     High,
     Max,
+    Xhigh,
 }
 
 impl ThinkingLevelArg {
@@ -41,6 +42,7 @@ impl ThinkingLevelArg {
             Self::Medium => "medium",
             Self::High => "high",
             Self::Max => "max",
+            Self::Xhigh => "xhigh",
         }
     }
 }

--- a/crates/ascend-tools-cli/src/otto.rs
+++ b/crates/ascend-tools-cli/src/otto.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::io::Write;
 use std::sync::mpsc;
@@ -5,8 +7,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use ascend_tools::client::AscendClient;
-use ascend_tools::models::{OttoChatRequest, StreamEvent};
-use clap::Subcommand;
+use ascend_tools::models::{OttoChatRequest, OttoStreamStatus, StreamEvent};
+use clap::{Subcommand, ValueEnum};
+use serde::Serialize;
 
 use crate::common::{OutputMode, print_json, print_subcommand_help, print_table};
 
@@ -17,6 +20,64 @@ use crate::common::{OutputMode, print_json, print_subcommand_help, print_table};
 enum RenderMsg {
     Delta(String),
     Done,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub(crate) enum ThinkingLevelArg {
+    None,
+    Minimal,
+    Low,
+    Medium,
+    High,
+    Max,
+}
+
+impl ThinkingLevelArg {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Minimal => "minimal",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Max => "max",
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct OttoJsonlRequestRecord {
+    record_type: &'static str,
+    base_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    binary_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_thread_id: Option<String>,
+    request_body: serde_json::Value,
+}
+
+#[derive(Serialize)]
+struct OttoJsonlEventRecord {
+    record_type: &'static str,
+    thread_id: String,
+    sequence: u64,
+    event_type: String,
+    raw_data: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+struct OttoJsonlTerminalRecord {
+    record_type: &'static str,
+    thread_id: String,
+    stream_status: OttoStreamStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream_error: Option<String>,
 }
 
 /// Renders Otto's streaming response with a spinner while waiting and
@@ -185,6 +246,18 @@ pub(crate) enum OttoCommands {
         #[arg(long)]
         model: Option<String>,
 
+        /// Explicit thinking level for reasoning-capable models
+        #[arg(long, value_enum)]
+        thinking: Option<ThinkingLevelArg>,
+
+        /// Print reasoning and tool stream events to stderr
+        #[arg(long)]
+        debug_stream: bool,
+
+        /// Emit request provenance and raw Otto stream updates as JSONL
+        #[arg(long)]
+        jsonl: bool,
+
         /// Thread ID to continue a conversation (hidden, use --conversation instead)
         #[arg(long, hide = true)]
         thread: Option<String>,
@@ -282,10 +355,16 @@ pub(crate) fn handle_otto_cmd(
             uuid,
             provider,
             model,
+            thinking,
+            debug_stream,
+            jsonl,
             thread,
             conversation,
             resume,
         } => {
+            if jsonl && *output != OutputMode::Text {
+                anyhow::bail!("--jsonl cannot be combined with -o json");
+            }
             let runtime_uuid = client.resolve_optional_runtime_target(
                 workspace.as_deref(),
                 deployment.as_deref(),
@@ -304,7 +383,72 @@ pub(crate) fn handle_otto_cmd(
                 runtime_uuid,
                 thread_id,
                 model: client.resolve_otto_model(provider.as_deref(), model.as_deref())?,
+                thinking: thinking.map(|level| level.as_str().to_string()),
             };
+
+            if jsonl {
+                let request_body = serde_json::to_value(&request)?;
+                let request_record = OttoJsonlRequestRecord {
+                    record_type: "request",
+                    base_url: client.instance_api_url().to_string(),
+                    binary_path: std::env::current_exe()
+                        .ok()
+                        .map(|path| path.display().to_string()),
+                    provider: provider.clone(),
+                    model: request.model.as_ref().map(|model| model.id().to_string()),
+                    request_thread_id: request.thread_id.clone(),
+                    request_body,
+                };
+                println!(
+                    "{}",
+                    serde_json::to_string(&request_record)
+                        .expect("otto jsonl request record should always serialize")
+                );
+
+                let thread_id = RefCell::new(None::<String>);
+                let mut sequence = 0u64;
+                let response = client.otto_streaming_events(
+                    &request,
+                    |event| {
+                        sequence += 1;
+                        let record = OttoJsonlEventRecord {
+                            record_type: "event",
+                            thread_id: thread_id
+                                .borrow()
+                                .clone()
+                                .unwrap_or_else(|| "<unknown>".to_string()),
+                            sequence,
+                            event_type: event.event_type,
+                            raw_data: event.raw_data,
+                            data: event.data,
+                        };
+                        println!(
+                            "{}",
+                            serde_json::to_string(&record)
+                                .expect("otto jsonl event record should always serialize")
+                        );
+                        std::ops::ControlFlow::Continue(())
+                    },
+                    |tid| {
+                        *thread_id.borrow_mut() = Some(tid.to_string());
+                    },
+                )?;
+                let terminal_record = OttoJsonlTerminalRecord {
+                    record_type: "terminal",
+                    thread_id: response
+                        .thread_id
+                        .or_else(|| thread_id.borrow().clone())
+                        .unwrap_or_else(|| "<unknown>".to_string()),
+                    stream_status: response.stream_status,
+                    stream_error: response.stream_error,
+                };
+                println!(
+                    "{}",
+                    serde_json::to_string(&terminal_record)
+                        .expect("otto jsonl terminal record should always serialize")
+                );
+                return Ok(());
+            }
 
             match output {
                 OutputMode::Json => {
@@ -315,23 +459,72 @@ pub(crate) fn handle_otto_cmd(
                     }))?;
                 }
                 OutputMode::Text => {
-                    let mut renderer = StreamRenderer::start("");
+                    let mut renderer = (!debug_stream).then(|| StreamRenderer::start(""));
+                    let mut tool_names = HashMap::new();
+                    let mut tool_item_names = HashMap::new();
                     let mut thread_id = None;
                     client.otto_streaming(
                         &request,
                         |event| {
-                            if let StreamEvent::TextDelta(delta) = event {
-                                renderer.send_delta(delta);
+                            match event {
+                                StreamEvent::TextDelta(delta) => {
+                                    if let Some(renderer) = renderer.as_ref() {
+                                        renderer.send_delta(delta);
+                                    } else {
+                                        print!("{delta}");
+                                        let _ = std::io::stdout().flush();
+                                    }
+                                }
+                                StreamEvent::ReasoningDelta { item_id: _, delta } => {
+                                    if debug_stream {
+                                        eprintln!("[reasoning] {delta}");
+                                    }
+                                }
+                                StreamEvent::ToolCallStart {
+                                    item_id,
+                                    call_id,
+                                    name,
+                                    arguments,
+                                } => {
+                                    tool_names.insert(call_id, name.clone());
+                                    tool_item_names.insert(item_id, name.clone());
+                                    if debug_stream {
+                                        eprintln!("[tool start] {name} {arguments}");
+                                    }
+                                }
+                                StreamEvent::ToolCallArgsDelta { item_id, delta } => {
+                                    if debug_stream {
+                                        let name = tool_item_names
+                                            .get(&item_id)
+                                            .map(String::as_str)
+                                            .unwrap_or("tool");
+                                        eprintln!("[tool args] {name} {delta}");
+                                    }
+                                }
+                                StreamEvent::ToolCallOutput { call_id, output } => {
+                                    if debug_stream {
+                                        let name = tool_names
+                                            .get(&call_id)
+                                            .map(String::as_str)
+                                            .unwrap_or("tool");
+                                        eprintln!("[tool output] {name} {output}");
+                                    }
+                                }
                             }
                             std::ops::ControlFlow::Continue(())
                         },
                         |tid| {
                             thread_id = Some(tid.to_string());
+                            if debug_stream {
+                                eprintln!("thread: {tid}");
+                            }
                         },
                     )?;
-                    renderer.finish();
+                    if let Some(renderer) = renderer.as_mut() {
+                        renderer.finish();
+                    }
                     println!();
-                    if let Some(tid) = &thread_id {
+                    if !debug_stream && let Some(tid) = &thread_id {
                         eprintln!("thread: {tid}");
                     }
                 }

--- a/crates/ascend-tools-cli/src/skill-cli.md
+++ b/crates/ascend-tools-cli/src/skill-cli.md
@@ -102,6 +102,7 @@ ascend-tools flow get-run <RUN_NAME> --workspace <TITLE> | --deployment <TITLE>
 ```bash
 ascend-tools otto run "<PROMPT>" [--workspace <TITLE>] [--provider <NAME>] [--model <ID>] [--conversation <TITLE_OR_ID>]
 ascend-tools otto provider list
+ascend-tools -o json otto provider list   # includes per-model thinking_levels when available
 ascend-tools otto model list [--provider <NAME>]
 ascend-tools otto tui [--workspace <TITLE>] [--conversation <TITLE_OR_ID>]
 ```

--- a/crates/ascend-tools-cli/tests/cli_integration.rs
+++ b/crates/ascend-tools-cli/tests/cli_integration.rs
@@ -344,6 +344,58 @@ fn otto_run_jsonl_rejects_json_output_mode() {
 }
 
 #[test]
+fn otto_run_jsonl_accepts_xhigh_thinking_level() {
+    let mut server = Server::new();
+    mock_auth(&mut server);
+
+    server
+        .mock("POST", "/api/v1/otto/threads")
+        .match_header("authorization", "Bearer cli-token")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"thread_id":"thread-xhigh"}"#)
+        .expect(1)
+        .create();
+
+    let completed_details_body = serde_json::json!({
+        "id": "thread-xhigh",
+        "title": "Xhigh thinking",
+        "messages": {},
+        "updated_at": "2026-01-01T00:00:05Z",
+        "is_processing": false,
+        "context_window_stats": null,
+        "total_message_count": 2,
+        "has_more": false,
+        "oldest_message_id": "msg-user-1",
+        "latest_message_id": "msg-assistant-1"
+    })
+    .to_string();
+    let sse_body = format!("event: thread.details\ndata: {completed_details_body}\n\n");
+
+    server
+        .mock("GET", "/api/v1/otto/threads/thread-xhigh/updates")
+        .match_header("accept", "text/event-stream")
+        .with_status(200)
+        .with_body(sse_body)
+        .expect(1)
+        .create();
+
+    let mut cmd = command_with_auth(&server);
+    cmd.args([
+        "otto",
+        "run",
+        "Explain why xhigh matters.",
+        "--thinking",
+        "xhigh",
+        "--jsonl",
+    ]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\"thinking\":\"xhigh\""))
+        .stdout(predicate::str::contains("\"stream_status\":\"completed\""));
+}
+
+#[test]
 fn skill_install_writes_skill_file_to_target() {
     let temp_dir = TempDir::new().unwrap();
     let target = temp_dir.path().join("skills");

--- a/crates/ascend-tools-cli/tests/cli_integration.rs
+++ b/crates/ascend-tools-cli/tests/cli_integration.rs
@@ -18,12 +18,17 @@ fn command_with_auth(server: &Server) -> Command {
     cmd
 }
 
-fn mock_auth(server: &mut Server) {
+fn mock_auth_with_cloud_domain(server: &mut Server, cloud_api_domain: &str) {
     server
         .mock("GET", "/api/v1/auth/config")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"cloud_api_domain":"api.cloud.ascend.io"}"#)
+        .with_body(
+            serde_json::json!({
+                "cloud_api_domain": cloud_api_domain,
+            })
+            .to_string(),
+        )
         .expect(1)
         .create();
 
@@ -34,6 +39,10 @@ fn mock_auth(server: &mut Server) {
         .with_body(r#"{"access_token":"cli-token","expiration":4102444800}"#)
         .expect(1)
         .create();
+}
+
+fn mock_auth(server: &mut Server) {
+    mock_auth_with_cloud_domain(server, "api.cloud.ascend.io");
 }
 
 #[test]
@@ -393,6 +402,134 @@ fn otto_run_jsonl_accepts_xhigh_thinking_level() {
         .success()
         .stdout(predicate::str::contains("\"thinking\":\"xhigh\""))
         .stdout(predicate::str::contains("\"stream_status\":\"completed\""));
+}
+
+#[test]
+fn otto_run_jsonl_preserves_followup_thread_id() {
+    let mut server = Server::new();
+    mock_auth(&mut server);
+
+    server
+        .mock("POST", "/api/v1/otto/threads/existing-thread/messages")
+        .match_header("authorization", "Bearer cli-token")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"thread_id":"existing-thread"}"#)
+        .expect(1)
+        .create();
+
+    let completed_details_body = serde_json::json!({
+        "id": "existing-thread",
+        "title": "Follow-up thread",
+        "messages": {},
+        "updated_at": "2026-01-01T00:00:05Z",
+        "is_processing": false,
+        "context_window_stats": null,
+        "total_message_count": 2,
+        "has_more": false,
+        "oldest_message_id": "msg-user-1",
+        "latest_message_id": "msg-assistant-1"
+    })
+    .to_string();
+    let sse_body = format!("event: thread.details\ndata: {completed_details_body}\n\n");
+
+    server
+        .mock("GET", "/api/v1/otto/threads/existing-thread/updates")
+        .match_header("accept", "text/event-stream")
+        .with_status(200)
+        .with_body(sse_body)
+        .expect(1)
+        .create();
+
+    let mut cmd = command_with_auth(&server);
+    cmd.args([
+        "otto",
+        "run",
+        "Follow up briefly.",
+        "--thread",
+        "existing-thread",
+        "--thinking",
+        "medium",
+        "--jsonl",
+    ]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "\"request_thread_id\":\"existing-thread\"",
+        ))
+        .stdout(predicate::str::contains(
+            "\"thread_id\":\"existing-thread\"",
+        ))
+        .stdout(predicate::str::contains("\"stream_status\":\"completed\""));
+}
+
+#[test]
+fn otto_provider_list_json_includes_thinking_levels() {
+    let mut server = Server::new();
+    mock_auth(&mut server);
+
+    server
+        .mock("GET", "/api/v1/otto/providers")
+        .match_header("authorization", "Bearer cli-token")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!([{
+                "id": "openai",
+                "name": "OpenAI",
+                "default_model": "gpt-5.2",
+                "models": [
+                    {"id": "gpt-4.1", "name": "GPT-4.1"},
+                    {"id": "gpt-5.2", "name": "GPT-5.2"}
+                ]
+            }])
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+
+    server
+        .mock("GET", "/api/v1/otto/provider_settings")
+        .match_header("authorization", "Bearer cli-token")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "models": [
+                    {
+                        "provider_id": "openai",
+                        "id": "gpt-4.1",
+                        "name": "GPT-4.1",
+                        "enabled": true,
+                        "thinking_levels": []
+                    },
+                    {
+                        "provider_id": "openai",
+                        "id": "gpt-5.2",
+                        "name": "GPT-5.2",
+                        "enabled": true,
+                        "thinking_levels": ["none", "medium", "high"]
+                    }
+                ],
+                "providers": [
+                    {"id": "openai", "name": "OpenAI", "enabled": true}
+                ],
+                "default_provider_id": "openai",
+                "default_model_id": "gpt-5.2"
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+
+    let mut cmd = command_with_auth(&server);
+    cmd.args(["-o", "json", "otto", "provider", "list"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\"thinking_levels\": []"))
+        .stdout(predicate::str::contains(
+            "\"thinking_levels\": [\n          \"none\",\n          \"medium\",\n          \"high\"\n        ]",
+        ));
 }
 
 #[test]

--- a/crates/ascend-tools-cli/tests/cli_integration.rs
+++ b/crates/ascend-tools-cli/tests/cli_integration.rs
@@ -224,6 +224,126 @@ fn deployment_list_filters_by_kind() {
 }
 
 #[test]
+fn otto_run_jsonl_emits_request_event_and_terminal_records() {
+    let mut server = Server::new();
+    mock_auth(&mut server);
+
+    server
+        .mock("POST", "/api/v1/otto/threads")
+        .match_header("authorization", "Bearer cli-token")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"thread_id":"thread-jsonl"}"#)
+        .expect(1)
+        .create();
+
+    let reasoning_body = serde_json::json!({
+        "item_id": "rs_1",
+        "content_index": 0,
+        "delta": "Checking whether the failed flow needs a workspace restart."
+    })
+    .to_string();
+    let tool_added_body = serde_json::json!({
+        "item": {
+            "id": "fc_1",
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "get_flow_run",
+            "arguments": "{}"
+        }
+    })
+    .to_string();
+    let tool_args_body = serde_json::json!({
+        "item_id": "fc_1",
+        "delta": "{\"runtime\":\"workspace-prod\",\"flow\":\"orders/daily_sync\"}"
+    })
+    .to_string();
+    let tool_output_body = serde_json::json!({
+        "call_id": "call_1",
+        "output": "{\"status\":\"failed\",\"error\":\"warehouse timeout\"}"
+    })
+    .to_string();
+    let text_delta_body = serde_json::json!({
+        "delta": "The workspace is healthy; retry the flow once the warehouse is reachable."
+    })
+    .to_string();
+    let completed_details_body = serde_json::json!({
+        "id": "thread-jsonl",
+        "title": "Orders sync debug",
+        "messages": {},
+        "updated_at": "2026-01-01T00:00:05Z",
+        "is_processing": false,
+        "context_window_stats": null,
+        "total_message_count": 2,
+        "has_more": false,
+        "oldest_message_id": "msg-user-1",
+        "latest_message_id": "msg-assistant-1"
+    })
+    .to_string();
+    let sse_body = format!(
+        "event: response.reasoning_text.delta\ndata: {reasoning_body}\n\n\
+         event: response.output_item.added\ndata: {tool_added_body}\n\n\
+         event: response.function_call_arguments.delta\ndata: {tool_args_body}\n\n\
+         event: response.run_item_stream_event.tool_call_output_item\ndata: {tool_output_body}\n\n\
+         event: response.output_text.delta\ndata: {text_delta_body}\n\n\
+         event: thread.details\ndata: {completed_details_body}\n\n\
+         :ping\n\n"
+    );
+
+    server
+        .mock("GET", "/api/v1/otto/threads/thread-jsonl/updates")
+        .match_header("accept", "text/event-stream")
+        .with_status(200)
+        .with_body(sse_body)
+        .expect(1)
+        .create();
+
+    let mut cmd = command_with_auth(&server);
+    cmd.args([
+        "otto",
+        "run",
+        "Inspect the failed flow and explain whether it needs a restart.",
+        "--thinking",
+        "medium",
+        "--jsonl",
+    ]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\"record_type\":\"request\""))
+        .stdout(predicate::str::contains("\"thinking\":\"medium\""))
+        .stdout(predicate::str::contains("\"record_type\":\"event\""))
+        .stdout(predicate::str::contains(
+            "\"event_type\":\"response.reasoning_text.delta\"",
+        ))
+        .stdout(predicate::str::contains(
+            "\"event_type\":\"response.output_item.added\"",
+        ))
+        .stdout(predicate::str::contains(
+            "\"event_type\":\"response.function_call_arguments.delta\"",
+        ))
+        .stdout(predicate::str::contains(
+            "\"event_type\":\"response.run_item_stream_event.tool_call_output_item\"",
+        ))
+        .stdout(predicate::str::contains(
+            "\"event_type\":\"thread.details\"",
+        ))
+        .stdout(predicate::str::contains("\"is_processing\":false"))
+        .stdout(predicate::str::contains("\"thread_id\":\"thread-jsonl\""))
+        .stdout(predicate::str::contains("\"record_type\":\"terminal\""))
+        .stdout(predicate::str::contains("\"stream_status\":\"completed\""));
+}
+
+#[test]
+fn otto_run_jsonl_rejects_json_output_mode() {
+    let server = Server::new();
+    let mut cmd = command_with_auth(&server);
+    cmd.args(["-o", "json", "otto", "run", "hello", "--jsonl"]);
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "--jsonl cannot be combined with -o json",
+    ));
+}
+
+#[test]
 fn skill_install_writes_skill_file_to_target() {
     let temp_dir = TempDir::new().unwrap();
     let target = temp_dir.path().join("skills");

--- a/crates/ascend-tools-core/src/client.rs
+++ b/crates/ascend-tools-core/src/client.rs
@@ -652,11 +652,23 @@ impl AscendClient {
     /// use [`otto_streaming`] instead.
     pub fn otto(&self, request: &OttoChatRequest) -> Result<OttoChatResponse> {
         let mut full_message = String::new();
-        let response = self.otto_streaming(
+        let mut completed_snapshot_message = String::new();
+        let response = self.otto_streaming_events(
             request,
-            |event| {
-                if let StreamEvent::TextDelta(delta) = event {
+            |raw_event| {
+                if let Some(StreamEvent::TextDelta(delta)) =
+                    raw_otto_stream_update_to_stream_event(&raw_event)
+                {
                     full_message.push_str(&delta);
+                }
+                if raw_event.event_type == "thread.details"
+                    && is_completed_thread_details_snapshot(raw_event.data.as_ref())
+                {
+                    let snapshot_message =
+                        extract_completed_thread_details_message(raw_event.data.as_ref());
+                    if !snapshot_message.is_empty() {
+                        completed_snapshot_message = snapshot_message;
+                    }
                 }
                 ControlFlow::Continue(())
             },
@@ -670,7 +682,11 @@ impl AscendClient {
             });
         }
         Ok(OttoChatResponse {
-            message: full_message,
+            message: if !completed_snapshot_message.is_empty() {
+                completed_snapshot_message
+            } else {
+                full_message
+            },
             thread_id: response.thread_id,
             stream_status: OttoStreamStatus::Completed,
             stream_error: None,
@@ -1039,6 +1055,56 @@ fn is_completed_thread_details_snapshot(data: Option<&Value>) -> bool {
     data.and_then(|value| value.get("is_processing"))
         .and_then(Value::as_bool)
         == Some(false)
+}
+
+fn extract_completed_thread_details_message(data: Option<&Value>) -> String {
+    let Some(details) = data else {
+        return String::new();
+    };
+    let Some(messages) = details.get("messages") else {
+        return String::new();
+    };
+
+    if let (Some(messages_by_id), Some(latest_message_id)) = (
+        messages.as_object(),
+        details.get("latest_message_id").and_then(Value::as_str),
+    ) && let Some(message) = messages_by_id.get(latest_message_id)
+        && let Some(text) = extract_assistant_message_text(message)
+    {
+        return text;
+    }
+
+    match messages {
+        Value::Array(messages_list) => messages_list
+            .iter()
+            .rev()
+            .find_map(extract_assistant_message_text)
+            .unwrap_or_default(),
+        Value::Object(messages_by_id) => {
+            let mut latest_text = String::new();
+            let mut latest_created_at: Option<&str> = None;
+            for message in messages_by_id.values() {
+                let Some(text) = extract_assistant_message_text(message) else {
+                    continue;
+                };
+                let created_at = message.get("_created_at").and_then(Value::as_str);
+                if latest_text.is_empty() || created_at > latest_created_at {
+                    latest_created_at = created_at;
+                    latest_text = text;
+                }
+            }
+            latest_text
+        }
+        _ => String::new(),
+    }
+}
+
+fn extract_assistant_message_text(message: &Value) -> Option<String> {
+    if message.get("role").and_then(Value::as_str) != Some("assistant") {
+        return None;
+    }
+    let text = Conversation::extract_message_text(message);
+    if text.is_empty() { None } else { Some(text) }
 }
 
 fn extract_otto_stream_error(data: Option<&Value>) -> String {

--- a/crates/ascend-tools-core/src/client.rs
+++ b/crates/ascend-tools-core/src/client.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::io::BufReader;
 use std::ops::ControlFlow;
@@ -33,6 +34,19 @@ const STOP_THREAD_POLL_INTERVAL_MAX: Duration = Duration::from_millis(500);
 /// all buffered events on new subscriptions, producing duplicates.
 const SSE_CONNECT_MAX_RETRIES: u32 = 3;
 const SSE_CONNECT_BACKOFF: Duration = Duration::from_millis(500);
+
+#[derive(Debug, serde::Deserialize)]
+struct OttoProviderSettingsResponse {
+    models: Vec<OttoProviderSettingsModel>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct OttoProviderSettingsModel {
+    provider_id: String,
+    id: String,
+    #[serde(default)]
+    thinking_levels: Option<Vec<String>>,
+}
 
 fn encode_path(s: &str) -> String {
     utf8_percent_encode(s, PATH_SEGMENT).to_string()
@@ -549,7 +563,11 @@ impl AscendClient {
 
     /// List available Otto providers and their enabled models.
     pub fn list_otto_providers(&self) -> Result<Vec<OttoProvider>> {
-        self.get("/api/v1/otto/providers")
+        let mut providers: Vec<OttoProvider> = self.get("/api/v1/otto/providers")?;
+        if let Ok(settings) = self.get_otto_provider_settings() {
+            merge_otto_provider_thinking_levels(&mut providers, settings);
+        }
+        Ok(providers)
     }
 
     /// Resolve a provider name and model name to an [`OttoModel`] with IDs.
@@ -1023,6 +1041,10 @@ impl AscendClient {
 
         handle_response(resp, &context)
     }
+
+    fn get_otto_provider_settings(&self) -> Result<OttoProviderSettingsResponse> {
+        self.get("/api/v1/otto/provider_settings")
+    }
 }
 
 enum OttoStreamTerminal {
@@ -1270,6 +1292,28 @@ fn api_error(status: u16, body: &str) -> Error {
     Error::ApiError {
         status,
         message: body.to_string(),
+    }
+}
+
+fn merge_otto_provider_thinking_levels(
+    providers: &mut [OttoProvider],
+    settings: OttoProviderSettingsResponse,
+) {
+    let mut thinking_levels_by_model: HashMap<(String, String), Vec<String>> = settings
+        .models
+        .into_iter()
+        .filter_map(|model| {
+            model
+                .thinking_levels
+                .map(|thinking_levels| ((model.provider_id, model.id), thinking_levels))
+        })
+        .collect();
+
+    for provider in providers {
+        for model in &mut provider.models {
+            model.thinking_levels =
+                thinking_levels_by_model.remove(&(provider.id.clone(), model.id.clone()));
+        }
     }
 }
 

--- a/crates/ascend-tools-core/src/client.rs
+++ b/crates/ascend-tools-core/src/client.rs
@@ -13,8 +13,8 @@ use crate::error::{Error, JsonResultExt, Result, UreqResultExt};
 use crate::models::{
     Conversation, ConversationFilters, ConversationList, Deployment, Environment, Flow, FlowRun,
     FlowRunFilters, FlowRunList, FlowRunTrigger, OttoChatRequest, OttoChatResponse, OttoModel,
-    OttoProvider, OttoStreamStatus, Project, Runtime, RuntimeCreate, RuntimeFilters, RuntimeKind,
-    RuntimeUpdate, StreamEvent, Workspace,
+    OttoProvider, OttoStreamStatus, OttoStreamUpdate, Project, Runtime, RuntimeCreate,
+    RuntimeFilters, RuntimeKind, RuntimeUpdate, StreamEvent, Workspace,
 };
 use crate::sse::SseReader;
 
@@ -677,25 +677,48 @@ impl AscendClient {
         })
     }
 
+    /// Send a message to Otto and expose the raw per-thread SSE updates.
+    pub fn otto_streaming_events(
+        &self,
+        request: &OttoChatRequest,
+        on_event: impl FnMut(OttoStreamUpdate) -> ControlFlow<()>,
+        on_thread_id: impl FnOnce(&str),
+    ) -> Result<OttoChatResponse> {
+        let thread_id = self.start_otto_request(request)?;
+        on_thread_id(&thread_id);
+        self.stream_otto_updates(&thread_id, on_event)
+    }
+
     /// Send a message to Otto, streaming events to `on_event` as they arrive.
     ///
     /// `on_thread_id` is called with the thread ID as soon as the thread is
     /// created (before any events arrive). `on_event` receives each stream
-    /// event (text deltas, tool calls) and returns `ControlFlow::Continue(())`
-    /// to keep streaming or `ControlFlow::Break(())` to cancel early. The
-    /// returned `OttoChatResponse` has an empty `message` — the caller is
-    /// expected to have accumulated the text via the callback.
+    /// event (text deltas, reasoning deltas, tool calls) and returns
+    /// `ControlFlow::Continue(())` to keep streaming or
+    /// `ControlFlow::Break(())` to cancel early. The returned
+    /// `OttoChatResponse` has an empty `message` — the caller is expected to
+    /// have accumulated the text via the callback.
     pub fn otto_streaming(
         &self,
         request: &OttoChatRequest,
         mut on_event: impl FnMut(StreamEvent) -> ControlFlow<()>,
         on_thread_id: impl FnOnce(&str),
     ) -> Result<OttoChatResponse> {
+        self.otto_streaming_events(
+            request,
+            |raw_event| match raw_otto_stream_update_to_stream_event(&raw_event) {
+                Some(stream_event) => on_event(stream_event),
+                None => ControlFlow::Continue(()),
+            },
+            on_thread_id,
+        )
+    }
+
+    fn start_otto_request(&self, request: &OttoChatRequest) -> Result<String> {
         let body =
             serde_json::to_value(request).with_json_serialize_context("OttoChatRequest body")?;
         let token = self.auth.get_token()?;
 
-        // Step 1: Create thread or send message to existing thread
         let (path, context) = if let Some(ref tid) = request.thread_id {
             let encoded = encode_path(tid);
             (
@@ -718,7 +741,7 @@ impl AscendClient {
             let mut last_err = None;
             let mut resp_val = None;
             let mut sent_stop = false;
-            let mut current_token = token.clone();
+            let mut current_token = token;
             loop {
                 let resp = self
                     .agent
@@ -731,8 +754,6 @@ impl AscendClient {
                 if status == 409 && is_follow_up {
                     let body_str = resp.into_body().read_to_string().unwrap_or_default();
                     last_err = Some(api_error(status, &body_str));
-                    // Send stop once (fire-and-forget) to nudge the backend,
-                    // then retry the POST until the thread finishes processing.
                     if !sent_stop {
                         if let Some(ref tid) = request.thread_id {
                             let _ = self.stop_thread(tid);
@@ -743,7 +764,6 @@ impl AscendClient {
                         break;
                     }
                     std::thread::sleep(FOLLOW_UP_RETRY_INTERVAL);
-                    // Refresh token on retry (may have expired during wait)
                     current_token = self.auth.get_token()?;
                     continue;
                 }
@@ -756,25 +776,28 @@ impl AscendClient {
             }
         };
 
-        let thread_id = create_resp
+        create_resp
             .get("thread_id")
             .and_then(|v| v.as_str())
+            .map(str::to_string)
             .ok_or_else(|| Error::ApiError {
                 status: 500,
                 message: "missing thread_id in response".to_string(),
-            })?
-            .to_string();
+            })
+    }
 
-        on_thread_id(&thread_id);
-
-        // Step 2: Connect to the SSE updates stream.
-        //
+    fn stream_otto_updates(
+        &self,
+        thread_id: &str,
+        mut on_event: impl FnMut(OttoStreamUpdate) -> ControlFlow<()>,
+    ) -> Result<OttoChatResponse> {
         // The backend SSE stream never closes naturally — it sends heartbeat
-        // pings every 30s and stays open for future messages on the thread.
-        // On new subscriptions it replays ALL buffered events from the start,
-        // so we only retry the initial connection (before any events arrive).
-        // Mid-stream reconnection would produce duplicate text.
-        let updates_path = format!("/api/v1/otto/threads/{}/updates", encode_path(&thread_id));
+        // pings every 30s and stays open for future updates on the thread.
+        // New subscriptions begin with a `thread.details` snapshot before any
+        // live response events, so we only retry the initial connection (before
+        // any events arrive). Mid-stream reconnection could duplicate caller-
+        // visible updates or re-deliver a completed snapshot.
+        let updates_path = format!("/api/v1/otto/threads/{}/updates", encode_path(thread_id));
         let updates_url = format!("{}{updates_path}", self.instance_api_url);
         let updates_context = format!("GET {updates_path}");
 
@@ -786,12 +809,7 @@ impl AscendClient {
                     let backoff = SSE_CONNECT_BACKOFF * 2u32.pow(attempt - 1);
                     std::thread::sleep(backoff);
                 }
-                // Fresh token on retry (may have expired)
-                let stream_token = if attempt > 0 {
-                    self.auth.get_token()?
-                } else {
-                    token.clone()
-                };
+                let stream_token = self.auth.get_token()?;
                 match self
                     .streaming_agent
                     .get(&updates_url)
@@ -810,7 +828,7 @@ impl AscendClient {
                 Some(r) => r,
                 None => {
                     return Err(Error::RequestFailed {
-                        context: updates_context,
+                        context: updates_context.clone(),
                         source: last_err.unwrap(),
                     });
                 }
@@ -818,19 +836,14 @@ impl AscendClient {
         };
 
         if !(200..300).contains(&updates_resp.status().as_u16()) {
-            // Non-2xx on SSE connect is an interruption, not a completed stream.
-            // check_error_status will return Err for non-2xx, but if it somehow
-            // returns Ok, mark as Interrupted rather than misleadingly Completed.
             return check_error_status(updates_resp, &updates_context).map(|()| OttoChatResponse {
                 message: String::new(),
-                thread_id: Some(thread_id),
+                thread_id: Some(thread_id.to_string()),
                 stream_status: OttoStreamStatus::Interrupted,
                 stream_error: Some(format!("{updates_context} returned non-2xx status")),
             });
         }
 
-        // Parse SSE stream, dispatching events to the caller.
-        // No mid-stream reconnection — see comment above.
         let reader = BufReader::new(updates_resp.into_body().into_reader());
 
         let mut saw_terminal_event = false;
@@ -839,90 +852,27 @@ impl AscendClient {
 
         for event_result in SseReader::new(reader) {
             let event = event_result?;
-            let event_type = event.event_type.as_deref();
-
-            if event_type == Some("thread.done") || event_type == Some("thread.stopped") {
-                saw_terminal_event = true;
-                break;
-            }
-
-            // response.error is a terminal event from the backend indicating
-            // the response failed (e.g. context window exceeded, model error).
-            // Treat it like a stream interruption with the error message.
-            if event_type == Some("response.error") {
-                let error_msg = serde_json::from_str::<Value>(&event.data)
-                    .ok()
-                    .and_then(|d| {
-                        // Try common error payload keys: error, message, detail
-                        d.get("error")
-                            .or_else(|| d.get("message"))
-                            .or_else(|| d.get("detail"))
-                            .and_then(|v| v.as_str())
-                            .map(String::from)
-                    })
-                    .unwrap_or_else(|| "response error".to_string());
-                response_error = Some(error_msg);
-                break;
-            }
-
-            // Skip heartbeats and unknown event types without data
-            let Ok(data) = serde_json::from_str::<Value>(&event.data) else {
-                continue;
+            let raw_event = OttoStreamUpdate {
+                event_type: event.event_type.unwrap_or_default(),
+                data: parse_otto_stream_update_data(&event.data),
+                raw_data: event.data,
             };
+            let callback_break = on_event(raw_event.clone()).is_break();
 
-            let stream_event = match event_type {
-                Some("response.output_text.delta") => data
-                    .get("delta")
-                    .and_then(|v| v.as_str())
-                    .map(|d| StreamEvent::TextDelta(d.to_string())),
-                Some("response.output_item.added") => {
-                    let Some(item) = data.get("item") else {
-                        continue;
-                    };
-                    if item.get("type").and_then(|v| v.as_str()) == Some("function_call") {
-                        Some(StreamEvent::ToolCallStart {
-                            call_id: item
-                                .get("call_id")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            name: item
-                                .get("name")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            arguments: item
-                                .get("arguments")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("{}")
-                                .to_string(),
-                        })
-                    } else {
-                        None
-                    }
+            match classify_otto_stream_terminal(&raw_event) {
+                Some(OttoStreamTerminal::Completed) => {
+                    saw_terminal_event = true;
+                    break;
                 }
-                Some("response.run_item_stream_event.tool_call_output_item") => {
-                    Some(StreamEvent::ToolCallOutput {
-                        call_id: data
-                            .get("call_id")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or_default()
-                            .to_string(),
-                        output: data
-                            .get("output")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string(),
-                    })
+                Some(OttoStreamTerminal::Interrupted(err)) => {
+                    response_error = Some(err);
+                    break;
                 }
-                _ => None,
-            };
-
-            if let Some(se) = stream_event
-                && on_event(se).is_break()
-            {
-                cancelled_by_callback = true;
-                break;
+                None if callback_break => {
+                    cancelled_by_callback = true;
+                    break;
+                }
+                None => {}
             }
         }
 
@@ -941,7 +891,7 @@ impl AscendClient {
 
         Ok(OttoChatResponse {
             message: String::new(),
-            thread_id: Some(thread_id),
+            thread_id: Some(thread_id.to_string()),
             stream_status,
             stream_error,
         })
@@ -1056,6 +1006,130 @@ impl AscendClient {
         };
 
         handle_response(resp, &context)
+    }
+}
+
+enum OttoStreamTerminal {
+    Completed,
+    Interrupted(String),
+}
+
+fn parse_otto_stream_update_data(raw_data: &str) -> Option<Value> {
+    if raw_data.is_empty() {
+        None
+    } else {
+        serde_json::from_str(raw_data).ok()
+    }
+}
+
+fn classify_otto_stream_terminal(event: &OttoStreamUpdate) -> Option<OttoStreamTerminal> {
+    match event.event_type.as_str() {
+        "thread.done" | "thread.stopped" => Some(OttoStreamTerminal::Completed),
+        "thread.details" if is_completed_thread_details_snapshot(event.data.as_ref()) => {
+            Some(OttoStreamTerminal::Completed)
+        }
+        "response.error" => Some(OttoStreamTerminal::Interrupted(extract_otto_stream_error(
+            event.data.as_ref(),
+        ))),
+        _ => None,
+    }
+}
+
+fn is_completed_thread_details_snapshot(data: Option<&Value>) -> bool {
+    data.and_then(|value| value.get("is_processing"))
+        .and_then(Value::as_bool)
+        == Some(false)
+}
+
+fn extract_otto_stream_error(data: Option<&Value>) -> String {
+    data.and_then(|value| {
+        value
+            .get("error")
+            .or_else(|| value.get("message"))
+            .or_else(|| value.get("detail"))
+            .and_then(|field| field.as_str())
+            .map(String::from)
+    })
+    .unwrap_or_else(|| "response error".to_string())
+}
+
+fn raw_otto_stream_update_to_stream_event(event: &OttoStreamUpdate) -> Option<StreamEvent> {
+    let data = event.data.as_ref()?;
+    match event.event_type.as_str() {
+        "response.output_text.delta" => data
+            .get("delta")
+            .and_then(|v| v.as_str())
+            .map(|d| StreamEvent::TextDelta(d.to_string())),
+        "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
+            Some(StreamEvent::ReasoningDelta {
+                item_id: data
+                    .get("item_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                delta: data
+                    .get("delta")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+            })
+        }
+        "response.output_item.added" => {
+            let item = data.get("item")?;
+            if item.get("type").and_then(|v| v.as_str()) == Some("function_call") {
+                Some(StreamEvent::ToolCallStart {
+                    item_id: item
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    call_id: item
+                        .get("call_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    name: item
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    arguments: item
+                        .get("arguments")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("{}")
+                        .to_string(),
+                })
+            } else {
+                None
+            }
+        }
+        "response.function_call_arguments.delta" => Some(StreamEvent::ToolCallArgsDelta {
+            item_id: data
+                .get("item_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            delta: data
+                .get("delta")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+        }),
+        "response.run_item_stream_event.tool_call_output_item" => {
+            Some(StreamEvent::ToolCallOutput {
+                call_id: data
+                    .get("call_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                output: data
+                    .get("output")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+            })
+        }
+        _ => None,
     }
 }
 

--- a/crates/ascend-tools-core/src/models.rs
+++ b/crates/ascend-tools-core/src/models.rs
@@ -415,4 +415,6 @@ pub struct OttoProvider {
 pub struct OttoProviderModel {
     pub id: String,
     pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking_levels: Option<Vec<String>>,
 }

--- a/crates/ascend-tools-core/src/models.rs
+++ b/crates/ascend-tools-core/src/models.rs
@@ -267,6 +267,8 @@ pub struct OttoChatRequest {
     pub thread_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<OttoModel>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
 }
 
 /// Terminal status for an Otto stream.
@@ -310,17 +312,31 @@ pub struct OttoChatResponse {
     pub stream_error: Option<String>,
 }
 
+/// A raw Otto stream update from the per-thread SSE endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OttoStreamUpdate {
+    pub event_type: String,
+    pub raw_data: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
 /// A streaming event from Otto.
 #[derive(Debug, Clone)]
 pub enum StreamEvent {
     /// A text delta from Otto's response.
     TextDelta(String),
+    /// A streamed reasoning delta from the current reasoning item.
+    ReasoningDelta { item_id: String, delta: String },
     /// A tool call has started.
     ToolCallStart {
+        item_id: String,
         call_id: String,
         name: String,
         arguments: String,
     },
+    /// Tool call arguments are still streaming in.
+    ToolCallArgsDelta { item_id: String, delta: String },
     /// A tool call has completed with output.
     ToolCallOutput { call_id: String, output: String },
 }

--- a/crates/ascend-tools-core/tests/client_http.rs
+++ b/crates/ascend-tools-core/tests/client_http.rs
@@ -17,12 +17,23 @@ fn test_client(server: &Server) -> AscendClient {
     AscendClient::new(config).unwrap()
 }
 
-fn mock_auth(server: &mut Server, token: &str, expiration: u64, token_expect: usize) {
+fn mock_auth_with_cloud_domain(
+    server: &mut Server,
+    token: &str,
+    expiration: u64,
+    token_expect: usize,
+    cloud_api_domain: &str,
+) {
     server
         .mock("GET", "/api/v1/auth/config")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"cloud_api_domain":"api.cloud.ascend.io"}"#)
+        .with_body(
+            serde_json::json!({
+                "cloud_api_domain": cloud_api_domain,
+            })
+            .to_string(),
+        )
         .expect(1)
         .create();
 
@@ -41,6 +52,16 @@ fn mock_auth(server: &mut Server, token: &str, expiration: u64, token_expect: us
         .create();
 }
 
+fn mock_auth(server: &mut Server, token: &str, expiration: u64, token_expect: usize) {
+    mock_auth_with_cloud_domain(
+        server,
+        token,
+        expiration,
+        token_expect,
+        "api.cloud.ascend.io",
+    );
+}
+
 #[test]
 fn otto_request_serializes_optional_thinking() {
     let request = OttoChatRequest {
@@ -56,6 +77,76 @@ fn otto_request_serializes_optional_thinking() {
     assert_eq!(body["runtime_uuid"], "rt-1");
     assert_eq!(body["thinking"], "medium");
     assert!(body.get("thread_id").is_none(), "thread_id is path-only");
+}
+
+#[test]
+fn otto_follow_up_posts_to_thread_messages_path() {
+    let mut server = Server::new();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    mock_auth(&mut server, "token-follow-up", now + 3600, 1);
+
+    server
+        .mock("POST", "/api/v1/otto/threads/thread-follow/messages")
+        .match_header("authorization", "Bearer token-follow-up")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"thread_id":"thread-follow"}"#)
+        .expect(1)
+        .create();
+
+    let completed_details_body = serde_json::json!({
+        "id": "thread-follow",
+        "title": "Follow-up thread",
+        "messages": {
+            "msg-assistant-1": {
+                "id": "msg-assistant-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "The follow-up stayed on the existing thread."
+                    }
+                ],
+                "_created_at": "2026-01-01T00:00:02Z"
+            }
+        },
+        "latest_message_id": "msg-assistant-1",
+        "updated_at": "2026-01-01T00:00:02Z",
+        "is_processing": false
+    })
+    .to_string();
+    let sse_body = format!("event: thread.details\ndata: {completed_details_body}\n\n");
+
+    server
+        .mock("GET", "/api/v1/otto/threads/thread-follow/updates")
+        .match_header("accept", "text/event-stream")
+        .with_status(200)
+        .with_body(sse_body)
+        .expect(1)
+        .create();
+
+    let client = test_client(&server);
+    let request = OttoChatRequest {
+        prompt: "umm".into(),
+        runtime_uuid: None,
+        thread_id: Some("thread-follow".into()),
+        model: Some(ascend_tools::models::OttoModel::new("gpt-5.4")),
+        thinking: Some("medium".into()),
+    };
+
+    let response = client.otto(&request).unwrap();
+    assert_eq!(
+        response.message,
+        "The follow-up stayed on the existing thread."
+    );
+    assert_eq!(response.thread_id.as_deref(), Some("thread-follow"));
+    assert_eq!(response.stream_status, OttoStreamStatus::Completed);
+    assert!(response.stream_error.is_none());
 }
 
 #[test]
@@ -1763,6 +1854,142 @@ fn resolve_otto_provider_not_found_lists_available() {
         err_str.contains("AWS Bedrock"),
         "should list available providers: {err_str}"
     );
+}
+
+#[test]
+fn list_otto_providers_merges_thinking_levels_from_provider_settings() {
+    let mut server = Server::new();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    mock_auth(&mut server, "token-provider-settings", now + 3600, 1);
+
+    let providers = server
+        .mock("GET", "/api/v1/otto/providers")
+        .match_header("authorization", "Bearer token-provider-settings")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!([{
+                "id": "openai",
+                "name": "OpenAI",
+                "default_model": "gpt-5.2",
+                "models": [
+                    {"id": "gpt-4.1", "name": "GPT-4.1"},
+                    {"id": "gpt-5.2", "name": "GPT-5.2"}
+                ]
+            }])
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+
+    let provider_settings = server
+        .mock("GET", "/api/v1/otto/provider_settings")
+        .match_header("authorization", "Bearer token-provider-settings")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!({
+                "models": [
+                    {
+                        "provider_id": "openai",
+                        "id": "gpt-4.1",
+                        "name": "GPT-4.1",
+                        "enabled": true,
+                        "thinking_levels": []
+                    },
+                    {
+                        "provider_id": "openai",
+                        "id": "gpt-5.2",
+                        "name": "GPT-5.2",
+                        "enabled": true,
+                        "thinking_levels": ["none", "medium", "high"]
+                    },
+                    {
+                        "provider_id": "openai",
+                        "id": "gpt-5.4",
+                        "name": "GPT-5.4",
+                        "enabled": true,
+                        "thinking_levels": ["none", "high"]
+                    }
+                ],
+                "providers": [
+                    {"id": "openai", "name": "OpenAI", "enabled": true}
+                ],
+                "default_provider_id": "openai",
+                "default_model_id": "gpt-5.2"
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+
+    let client = test_client(&server);
+    let result = client.list_otto_providers().unwrap();
+
+    providers.assert();
+    provider_settings.assert();
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result[0].models[0].thinking_levels,
+        Some(Vec::<String>::new())
+    );
+    assert_eq!(
+        result[0].models[1].thinking_levels,
+        Some(vec![
+            "none".to_string(),
+            "medium".to_string(),
+            "high".to_string(),
+        ])
+    );
+}
+
+#[test]
+fn list_otto_providers_falls_back_when_provider_settings_lookup_fails() {
+    let mut server = Server::new();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    mock_auth(&mut server, "token-provider-fallback", now + 3600, 1);
+
+    let providers = server
+        .mock("GET", "/api/v1/otto/providers")
+        .match_header("authorization", "Bearer token-provider-fallback")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            serde_json::json!([{
+                "id": "openai",
+                "name": "OpenAI",
+                "default_model": "gpt-5.2",
+                "models": [
+                    {"id": "gpt-5.2", "name": "GPT-5.2"}
+                ]
+            }])
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+
+    let provider_settings = server
+        .mock("GET", "/api/v1/otto/provider_settings")
+        .match_header("authorization", "Bearer token-provider-fallback")
+        .with_status(502)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"detail":"bad gateway"}"#)
+        .expect(1)
+        .create();
+
+    let client = test_client(&server);
+    let result = client.list_otto_providers().unwrap();
+
+    providers.assert();
+    provider_settings.assert();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].models[0].thinking_levels, None);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ascend-tools-core/tests/client_http.rs
+++ b/crates/ascend-tools-core/tests/client_http.rs
@@ -1125,6 +1125,167 @@ fn otto_streaming_events_complete_on_completed_thread_details_snapshot() {
     assert!(response.stream_error.is_none());
 }
 
+#[test]
+fn otto_reconstructs_final_message_from_completed_thread_details_snapshot_without_latest_message_id()
+ {
+    let mut server = Server::new();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    mock_auth(&mut server, "token-final-snapshot", now + 3600, 1);
+
+    server
+        .mock("POST", "/api/v1/otto/threads")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"thread_id":"t-final-snapshot"}"#)
+        .expect(1)
+        .create();
+
+    let completed_details_body = serde_json::json!({
+        "id": "t-final-snapshot",
+        "title": "Final snapshot",
+        "messages": {
+            "msg-user-1": {
+                "id": "msg-user-1",
+                "type": "message",
+                "role": "user",
+                "content": "Explain the API URL."
+            },
+            "msg-assistant-0": {
+                "id": "msg-assistant-0",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "Old reply that should not win."
+                    }
+                ],
+                "_created_at": "2026-01-01T00:00:01Z"
+            },
+            "msg-assistant-1": {
+                "id": "msg-assistant-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "ASCEND_INSTANCE_API_URL points ascend-tools at the instance API."
+                    }
+                ],
+                "_created_at": "2026-01-01T00:00:02Z"
+            }
+        },
+        "updated_at": "2026-01-01T00:00:02Z",
+        "is_processing": false
+    })
+    .to_string();
+    let sse_body = format!("event: thread.details\ndata: {completed_details_body}\n\n:ping\n\n");
+    server
+        .mock("GET", "/api/v1/otto/threads/t-final-snapshot/updates")
+        .with_status(200)
+        .with_body(sse_body)
+        .expect(1)
+        .create();
+
+    let client = test_client(&server);
+    let request = OttoChatRequest {
+        prompt: "Explain the API URL.".into(),
+        runtime_uuid: None,
+        thread_id: None,
+        model: None,
+        thinking: Some("medium".into()),
+    };
+
+    let response = client.otto(&request).unwrap();
+
+    assert_eq!(
+        response.message,
+        "ASCEND_INSTANCE_API_URL points ascend-tools at the instance API."
+    );
+    assert_eq!(response.thread_id.as_deref(), Some("t-final-snapshot"));
+    assert_eq!(response.stream_status, OttoStreamStatus::Completed);
+    assert!(response.stream_error.is_none());
+}
+
+#[test]
+fn otto_prefers_completed_thread_details_message_over_partial_text_deltas() {
+    let mut server = Server::new();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    mock_auth(&mut server, "token-partial-snapshot", now + 3600, 1);
+
+    server
+        .mock("POST", "/api/v1/otto/threads")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"thread_id":"t-partial-snapshot"}"#)
+        .expect(1)
+        .create();
+
+    let partial_delta_body = serde_json::json!({
+        "delta": "The warehouse timed out. "
+    })
+    .to_string();
+    let completed_details_body = serde_json::json!({
+        "id": "t-partial-snapshot",
+        "title": "Warehouse timeout",
+        "messages": {
+            "msg-assistant-1": {
+                "id": "msg-assistant-1",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "The warehouse timed out during orders sync. Retry the flow after the warehouse recovers."
+                    }
+                ],
+                "_created_at": "2026-01-01T00:00:03Z"
+            }
+        },
+        "latest_message_id": "msg-assistant-1",
+        "updated_at": "2026-01-01T00:00:03Z",
+        "is_processing": false
+    })
+    .to_string();
+    let sse_body = format!(
+        "event: response.output_text.delta\ndata: {partial_delta_body}\n\n\
+         event: thread.details\ndata: {completed_details_body}\n\n"
+    );
+    server
+        .mock("GET", "/api/v1/otto/threads/t-partial-snapshot/updates")
+        .with_status(200)
+        .with_body(sse_body)
+        .expect(1)
+        .create();
+
+    let client = test_client(&server);
+    let request = OttoChatRequest {
+        prompt: "Why did the sync fail?".into(),
+        runtime_uuid: None,
+        thread_id: None,
+        model: None,
+        thinking: Some("medium".into()),
+    };
+
+    let response = client.otto(&request).unwrap();
+
+    assert_eq!(
+        response.message,
+        "The warehouse timed out during orders sync. Retry the flow after the warehouse recovers."
+    );
+    assert_eq!(response.thread_id.as_deref(), Some("t-partial-snapshot"));
+    assert_eq!(response.stream_status, OttoStreamStatus::Completed);
+}
+
 // ---------------------------------------------------------------------------
 // Otto streaming: SSE endpoint returns HTTP error
 // ---------------------------------------------------------------------------

--- a/crates/ascend-tools-core/tests/client_http.rs
+++ b/crates/ascend-tools-core/tests/client_http.rs
@@ -42,6 +42,113 @@ fn mock_auth(server: &mut Server, token: &str, expiration: u64, token_expect: us
 }
 
 #[test]
+fn otto_request_serializes_optional_thinking() {
+    let request = OttoChatRequest {
+        prompt: "hello".into(),
+        runtime_uuid: Some("rt-1".into()),
+        thread_id: Some("thread-1".into()),
+        model: None,
+        thinking: Some("medium".into()),
+    };
+
+    let body = serde_json::to_value(&request).unwrap();
+    assert_eq!(body["prompt"], "hello");
+    assert_eq!(body["runtime_uuid"], "rt-1");
+    assert_eq!(body["thinking"], "medium");
+    assert!(body.get("thread_id").is_none(), "thread_id is path-only");
+}
+
+#[test]
+fn otto_streaming_events_exposes_raw_updates() {
+    let mut server = Server::new();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    mock_auth(&mut server, "token-raw-stream", now + 3600, 1);
+
+    server
+        .mock("POST", "/api/v1/otto/threads")
+        .match_header("authorization", "Bearer token-raw-stream")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"thread_id":"thread-raw"}"#)
+        .expect(1)
+        .create();
+
+    let preview_body = serde_json::json!({
+        "id": "thread-raw",
+        "title": "Raw thread",
+        "messages": {},
+        "updated_at": "2026-01-01T00:00:00Z",
+        "is_processing": true,
+        "context_window_stats": null,
+        "total_message_count": 1,
+        "has_more": false,
+        "oldest_message_id": null,
+        "latest_message_id": "msg-1"
+    })
+    .to_string();
+    let sse_body = format!(
+        "event: thread.preview\ndata: {preview_body}\n\n\
+         event: response.reasoning_summary_text.delta\ndata: {{\"item_id\":\"rs_1\",\"delta\":\"Thinking...\"}}\n\n\
+         event: thread.done\ndata: {{}}\n\n"
+    );
+
+    let updates = server
+        .mock("GET", "/api/v1/otto/threads/thread-raw/updates")
+        .match_header("accept", "text/event-stream")
+        .with_status(200)
+        .with_body(sse_body)
+        .expect(1)
+        .create();
+
+    let client = test_client(&server);
+    let request = OttoChatRequest {
+        prompt: "hello".into(),
+        runtime_uuid: None,
+        thread_id: None,
+        model: None,
+        thinking: Some("medium".into()),
+    };
+
+    let mut observed_thread_id = None;
+    let mut event_types = Vec::new();
+    let mut raw_payloads = Vec::new();
+    let response = client
+        .otto_streaming_events(
+            &request,
+            |event| {
+                event_types.push(event.event_type.clone());
+                raw_payloads.push((event.raw_data.clone(), event.data.clone()));
+                ControlFlow::Continue(())
+            },
+            |tid| {
+                observed_thread_id = Some(tid.to_string());
+            },
+        )
+        .unwrap();
+
+    updates.assert();
+    assert_eq!(observed_thread_id.as_deref(), Some("thread-raw"));
+    assert_eq!(
+        event_types,
+        vec![
+            "thread.preview",
+            "response.reasoning_summary_text.delta",
+            "thread.done",
+        ]
+    );
+    assert!(raw_payloads[0].0.contains("\"id\":\"thread-raw\""));
+    assert_eq!(
+        raw_payloads[1].1.as_ref().unwrap()["delta"],
+        serde_json::json!("Thinking...")
+    );
+    assert_eq!(response.thread_id.as_deref(), Some("thread-raw"));
+    assert_eq!(response.stream_status, OttoStreamStatus::Completed);
+}
+
+#[test]
 fn api_error_prefers_detail_field_when_present() {
     let mut server = Server::new();
     let now = SystemTime::now()
@@ -417,6 +524,7 @@ fn otto_streaming_interrupted_when_sse_closes_without_terminal_event() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let mut observed_thread_id = None;
@@ -490,6 +598,7 @@ fn otto_streaming_completes_on_thread_done() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let mut text = String::new();
@@ -551,6 +660,7 @@ fn otto_streaming_completes_on_thread_stopped() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let mut text = String::new();
@@ -613,6 +723,7 @@ fn otto_streaming_cancelled_by_callback() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let mut delta_count = 0;
@@ -678,6 +789,7 @@ fn otto_streaming_handles_response_error_event() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let mut text = String::new();
@@ -730,8 +842,12 @@ fn otto_streaming_dispatches_tool_call_events() {
         .create();
 
     let sse_body = concat!(
+        "event: response.reasoning_text.delta\n",
+        "data: {\"item_id\":\"rs_1\",\"content_index\":0,\"delta\":\"Thinking...\"}\n\n",
         "event: response.output_item.added\n",
-        "data: {\"item\":{\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"list_flows\",\"arguments\":\"{}\"}}\n\n",
+        "data: {\"item\":{\"id\":\"fc_1\",\"type\":\"function_call\",\"call_id\":\"c1\",\"name\":\"list_flows\",\"arguments\":\"{}\"}}\n\n",
+        "event: response.function_call_arguments.delta\n",
+        "data: {\"item_id\":\"fc_1\",\"delta\":\"{\\\"path\\\":\\\".\\\"}\"}\n\n",
         "event: response.run_item_stream_event.tool_call_output_item\n",
         "data: {\"call_id\":\"c1\",\"output\":\"[{\\\"name\\\":\\\"sales\\\"}]\"}\n\n",
         "event: response.output_text.delta\ndata: {\"delta\":\"Found 1 flow.\"}\n\n",
@@ -751,6 +867,7 @@ fn otto_streaming_dispatches_tool_call_events() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let mut events_log: Vec<String> = Vec::new();
@@ -760,8 +877,14 @@ fn otto_streaming_dispatches_tool_call_events() {
             |event| {
                 match &event {
                     StreamEvent::TextDelta(d) => events_log.push(format!("delta:{d}")),
+                    StreamEvent::ReasoningDelta { delta, .. } => {
+                        events_log.push(format!("reasoning:{delta}"))
+                    }
                     StreamEvent::ToolCallStart { name, call_id, .. } => {
                         events_log.push(format!("tool_start:{name}:{call_id}"))
+                    }
+                    StreamEvent::ToolCallArgsDelta { item_id, delta } => {
+                        events_log.push(format!("tool_args:{item_id}:{delta}"))
                     }
                     StreamEvent::ToolCallOutput { call_id, output } => {
                         events_log.push(format!("tool_output:{call_id}:{output}"))
@@ -777,7 +900,9 @@ fn otto_streaming_dispatches_tool_call_events() {
     assert_eq!(
         events_log,
         vec![
+            "reasoning:Thinking...",
             "tool_start:list_flows:c1",
+            "tool_args:fc_1:{\"path\":\".\"}",
             "tool_output:c1:[{\"name\":\"sales\"}]",
             "delta:Found 1 flow.",
         ]
@@ -827,6 +952,7 @@ fn otto_streaming_skips_heartbeats_and_comments() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let mut text = String::new();
@@ -845,6 +971,158 @@ fn otto_streaming_skips_heartbeats_and_comments() {
 
     assert_eq!(text, "ab");
     assert_eq!(response.stream_status, OttoStreamStatus::Completed);
+}
+
+// ---------------------------------------------------------------------------
+// Otto streaming: completed `thread.details` snapshot is terminal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn otto_streaming_events_complete_on_completed_thread_details_snapshot() {
+    let mut server = Server::new();
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    mock_auth(&mut server, "token-details-done", now + 3600, 1);
+
+    server
+        .mock("POST", "/api/v1/otto/threads")
+        .match_header("authorization", "Bearer token-details-done")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"thread_id":"t-details-done"}"#)
+        .expect(1)
+        .create();
+
+    let initial_details_body = serde_json::json!({
+        "id": "t-details-done",
+        "title": "Orders sync debug",
+        "messages": {},
+        "updated_at": "2026-01-01T00:00:00Z",
+        "is_processing": true,
+        "context_window_stats": null,
+        "total_message_count": 1,
+        "has_more": false,
+        "oldest_message_id": "msg-user-1",
+        "latest_message_id": "msg-user-1"
+    })
+    .to_string();
+    let reasoning_body = serde_json::json!({
+        "item_id": "rs_1",
+        "content_index": 0,
+        "delta": "Checking the deployment state before answering."
+    })
+    .to_string();
+    let tool_added_body = serde_json::json!({
+        "item": {
+            "id": "fc_1",
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "get_flow_run",
+            "arguments": "{}"
+        }
+    })
+    .to_string();
+    let tool_args_body = serde_json::json!({
+        "item_id": "fc_1",
+        "delta": "{\"runtime\":\"workspace-prod\",\"flow\":\"orders/daily_sync\"}"
+    })
+    .to_string();
+    let tool_output_body = serde_json::json!({
+        "call_id": "call_1",
+        "output": "{\"status\":\"failed\",\"error\":\"warehouse timeout\"}"
+    })
+    .to_string();
+    let text_delta_one_body = serde_json::json!({
+        "delta": "The last orders/daily_sync run failed because the warehouse timed out. "
+    })
+    .to_string();
+    let text_delta_two_body = serde_json::json!({
+        "delta": "No restart is needed; retry the flow after the warehouse recovers."
+    })
+    .to_string();
+    let completed_details_body = serde_json::json!({
+        "id": "t-details-done",
+        "title": "Orders sync debug",
+        "messages": {},
+        "updated_at": "2026-01-01T00:00:05Z",
+        "is_processing": false,
+        "context_window_stats": null,
+        "total_message_count": 2,
+        "has_more": false,
+        "oldest_message_id": "msg-user-1",
+        "latest_message_id": "msg-assistant-1"
+    })
+    .to_string();
+    let sse_body = format!(
+        "event: thread.details\ndata: {initial_details_body}\n\n\
+         event: response.reasoning_text.delta\ndata: {reasoning_body}\n\n\
+         event: response.output_item.added\ndata: {tool_added_body}\n\n\
+         event: response.function_call_arguments.delta\ndata: {tool_args_body}\n\n\
+         event: response.run_item_stream_event.tool_call_output_item\ndata: {tool_output_body}\n\n\
+         event: response.output_text.delta\ndata: {text_delta_one_body}\n\n\
+         event: response.output_text.delta\ndata: {text_delta_two_body}\n\n\
+         event: thread.details\ndata: {completed_details_body}\n\n\
+         :ping\n\n"
+    );
+    let updates = server
+        .mock("GET", "/api/v1/otto/threads/t-details-done/updates")
+        .match_header("accept", "text/event-stream")
+        .with_status(200)
+        .with_body(sse_body)
+        .expect(1)
+        .create();
+
+    let client = test_client(&server);
+    let request = OttoChatRequest {
+        prompt: "Inspect the failed orders sync and explain whether the workspace needs a restart."
+            .into(),
+        runtime_uuid: None,
+        thread_id: None,
+        model: None,
+        thinking: Some("high".into()),
+    };
+
+    let mut observed_thread_id = None;
+    let mut event_types = Vec::new();
+    let mut parsed_payloads = Vec::new();
+    let response = client
+        .otto_streaming_events(
+            &request,
+            |event| {
+                event_types.push(event.event_type.clone());
+                parsed_payloads.push(event.data.clone());
+                ControlFlow::Continue(())
+            },
+            |tid| {
+                observed_thread_id = Some(tid.to_string());
+            },
+        )
+        .unwrap();
+
+    updates.assert();
+    assert_eq!(observed_thread_id.as_deref(), Some("t-details-done"));
+    assert_eq!(
+        event_types,
+        vec![
+            "thread.details",
+            "response.reasoning_text.delta",
+            "response.output_item.added",
+            "response.function_call_arguments.delta",
+            "response.run_item_stream_event.tool_call_output_item",
+            "response.output_text.delta",
+            "response.output_text.delta",
+            "thread.details",
+        ]
+    );
+    assert_eq!(
+        parsed_payloads.last().as_ref().unwrap().as_ref().unwrap()["is_processing"],
+        serde_json::json!(false)
+    );
+    assert_eq!(response.thread_id.as_deref(), Some("t-details-done"));
+    assert_eq!(response.stream_status, OttoStreamStatus::Completed);
+    assert!(response.stream_error.is_none());
 }
 
 // ---------------------------------------------------------------------------
@@ -882,6 +1160,7 @@ fn otto_streaming_sse_endpoint_returns_error() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let result = client.otto_streaming(&request, |_| ControlFlow::Continue(()), |_| {});
@@ -922,6 +1201,7 @@ fn otto_streaming_thread_post_returns_error() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let result = client.otto_streaming(&request, |_| ControlFlow::Continue(()), |_| {});
@@ -968,6 +1248,7 @@ fn otto_non_streaming_errors_on_interrupted_stream() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     // otto() (non-streaming) should return an error for interrupted streams
@@ -1028,6 +1309,7 @@ fn otto_streaming_retries_409_on_follow_up() {
         runtime_uuid: None,
         thread_id: Some("t-existing".into()),
         model: None,
+        thinking: None,
     };
 
     let mut text = String::new();
@@ -1075,6 +1357,7 @@ fn otto_streaming_409_on_new_thread_returns_error() {
         runtime_uuid: None,
         thread_id: None, // new thread — no retry
         model: None,
+        thinking: None,
     };
 
     let result = client.otto_streaming(&request, |_| ControlFlow::Continue(()), |_| {});
@@ -1124,6 +1407,7 @@ fn otto_streaming_on_thread_id_called_before_events() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let callback_order = std::sync::Mutex::new(Vec::<String>::new());
@@ -1185,6 +1469,7 @@ fn otto_streaming_empty_sse_stream_returns_interrupted() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let response = client
@@ -1222,6 +1507,7 @@ fn otto_streaming_missing_thread_id_in_response() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let result = client.otto_streaming(&request, |_| ControlFlow::Continue(()), |_| {});
@@ -1357,6 +1643,7 @@ fn otto_streaming_response_error_without_message() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        thinking: None,
     };
 
     let response = client

--- a/crates/ascend-tools-js/package-lock.json
+++ b/crates/ascend-tools-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ascend-tools",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ascend-tools",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "bin": {
         "ascend-tools": "cli.js"

--- a/crates/ascend-tools-js/src/lib.rs
+++ b/crates/ascend-tools-js/src/lib.rs
@@ -370,26 +370,26 @@ impl Client {
 
     #[napi(ts_return_type = "Promise<OttoChatResponse>")]
     #[allow(clippy::too_many_arguments)]
-    pub fn otto(&self, prompt: String, workspace: Option<String>, deployment: Option<String>, uuid: Option<String>, thread_id: Option<String>, model: Option<String>, provider: Option<String>, conversation: Option<String>) -> AsyncTask<TypedTask<models::OttoChatResponse>> {
+    pub fn otto(&self, prompt: String, workspace: Option<String>, deployment: Option<String>, uuid: Option<String>, thread_id: Option<String>, model: Option<String>, provider: Option<String>, conversation: Option<String>, thinking: Option<String>) -> AsyncTask<TypedTask<models::OttoChatResponse>> {
         let client = self.inner.clone();
         AsyncTask::new(TypedTask::new(move || {
             let otto_model = client.resolve_otto_model(provider.as_deref(), model.as_deref()).map_err(to_napi_err)?;
             let runtime_uuid = client.resolve_optional_runtime_target(workspace.as_deref(), deployment.as_deref(), uuid.as_deref()).map_err(to_napi_err)?;
             let thread_id = client.resolve_otto_thread(conversation.as_deref(), thread_id).map_err(to_napi_err)?;
-            let request = models::OttoChatRequest { prompt, runtime_uuid, thread_id, model: otto_model };
+            let request = models::OttoChatRequest { prompt, runtime_uuid, thread_id, model: otto_model, thinking };
             client.otto(&request).map_err(to_napi_err)
         }))
     }
 
     #[napi(ts_return_type = "Promise<OttoChatResponse>")]
     #[allow(clippy::too_many_arguments)]
-    pub fn otto_streaming(&self, prompt: String, on_delta: ThreadsafeFunction<String, UnknownReturnValue>, workspace: Option<String>, deployment: Option<String>, uuid: Option<String>, thread_id: Option<String>, model: Option<String>, provider: Option<String>, conversation: Option<String>) -> AsyncTask<TypedTask<models::OttoChatResponse>> {
+    pub fn otto_streaming(&self, prompt: String, on_delta: ThreadsafeFunction<String, UnknownReturnValue>, workspace: Option<String>, deployment: Option<String>, uuid: Option<String>, thread_id: Option<String>, model: Option<String>, provider: Option<String>, conversation: Option<String>, thinking: Option<String>) -> AsyncTask<TypedTask<models::OttoChatResponse>> {
         let client = self.inner.clone();
         AsyncTask::new(TypedTask::new(move || {
             let otto_model = client.resolve_otto_model(provider.as_deref(), model.as_deref()).map_err(to_napi_err)?;
             let runtime_uuid = client.resolve_optional_runtime_target(workspace.as_deref(), deployment.as_deref(), uuid.as_deref()).map_err(to_napi_err)?;
             let thread_id = client.resolve_otto_thread(conversation.as_deref(), thread_id).map_err(to_napi_err)?;
-            let request = models::OttoChatRequest { prompt, runtime_uuid, thread_id, model: otto_model };
+            let request = models::OttoChatRequest { prompt, runtime_uuid, thread_id, model: otto_model, thinking };
             client.otto_streaming(&request, |event| { if let models::StreamEvent::TextDelta(delta) = event { on_delta.call(Ok(delta), ThreadsafeFunctionCallMode::NonBlocking); } std::ops::ControlFlow::Continue(()) }, |_| {}).map_err(to_napi_err)
         }))
     }

--- a/crates/ascend-tools-mcp/src/server.rs
+++ b/crates/ascend-tools-mcp/src/server.rs
@@ -524,6 +524,7 @@ impl AscendMcpServer {
                 runtime_uuid,
                 thread_id,
                 model,
+                thinking: None,
             })
         })
         .await

--- a/crates/ascend-tools-py/src/lib.rs
+++ b/crates/ascend-tools-py/src/lib.rs
@@ -503,7 +503,7 @@ impl Client {
         to_python(py, &providers)
     }
 
-    #[pyo3(signature = (*, prompt, workspace=None, deployment=None, uuid=None, thread_id=None, conversation=None, model=None, provider=None))]
+    #[pyo3(signature = (*, prompt, workspace=None, deployment=None, uuid=None, thread_id=None, conversation=None, model=None, provider=None, thinking=None))]
     #[allow(clippy::too_many_arguments)]
     fn otto(
         &self,
@@ -516,6 +516,7 @@ impl Client {
         conversation: Option<&str>,
         model: Option<&str>,
         provider: Option<&str>,
+        thinking: Option<&str>,
     ) -> PyResult<Py<PyAny>> {
         let response = py
             .detach(|| {
@@ -531,6 +532,7 @@ impl Client {
                     runtime_uuid,
                     thread_id,
                     model: otto_model,
+                    thinking: thinking.map(String::from),
                 };
                 self.inner.otto(&request)
             })

--- a/crates/ascend-tools-tui/src/lib.rs
+++ b/crates/ascend-tools-tui/src/lib.rs
@@ -823,6 +823,7 @@ impl App {
             runtime_uuid: self.runtime_uuid.clone(),
             thread_id: self.thread_id.clone(),
             model: self.otto_model.clone(),
+            thinking: None,
         });
         self.streaming = true;
         self.stream_buffer.clear();
@@ -2554,6 +2555,7 @@ pub fn run_tui(
                                     send(StreamMsgKind::Delta(delta));
                                 }
                                 StreamEvent::ToolCallStart {
+                                    item_id: _,
                                     call_id,
                                     name,
                                     arguments,
@@ -2566,6 +2568,8 @@ pub fn run_tui(
                                         tool_names.get(&call_id).cloned().unwrap_or_default();
                                     send(StreamMsgKind::ToolCallOutput { name, output });
                                 }
+                                StreamEvent::ReasoningDelta { .. }
+                                | StreamEvent::ToolCallArgsDelta { .. } => {}
                             }
                             ControlFlow::Continue(())
                         },
@@ -3515,6 +3519,7 @@ mod tests {
             runtime_uuid: None,
             thread_id: None,
             model: None,
+            thinking: None,
         });
 
         // The main loop guard is: if !app.interrupting && let Some(req) = app.take_pending_request()

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,3 +16,4 @@
 ## Contributing
 
 - [Development](DEVELOPMENT.md): contributor setup, architecture, release process
+- [Execution Plans](exec-plans/README.md): active and completed execution plans

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -241,6 +241,7 @@ ascend-tools otto run "Help me debug this pipeline" --provider "OpenAI" --model 
 
 # List providers and models
 ascend-tools otto provider list
+ascend-tools -o json otto provider list   # includes per-model thinking_levels when available
 ascend-tools otto model list
 ascend-tools otto model list --provider "OpenAI"
 

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,0 +1,13 @@
+# Execution Plans
+
+Execution plans capture active and completed work in a durable form that later contributors and agents can execute against.
+
+## Directories
+
+- [active/](active/README.md) — work currently in progress
+- [completed/](completed/README.md) — finished work retained for history
+
+## Conventions
+
+- Prefer ASE-shaped plan roots under `docs/exec-plans/active/<plan_slug>/`
+- Use `PLAN.md` as the human-facing entrypoint inside a plan root

--- a/docs/exec-plans/active/README.md
+++ b/docs/exec-plans/active/README.md
@@ -1,0 +1,9 @@
+# Active Execution Plans
+
+Work currently in progress.
+
+## Index
+
+| Plan | Description |
+|---|---|
+| [otto-validation-surface/PLAN.md](otto-validation-surface/PLAN.md) | Extend ascend-tools Otto surfaces into a faster backend-isolation and validation layer for reasoning, tool, and stream-lifecycle behavior. |

--- a/docs/exec-plans/active/otto-validation-surface/DECISIONS.md
+++ b/docs/exec-plans/active/otto-validation-surface/DECISIONS.md
@@ -30,9 +30,36 @@ Reason:
 - this repo is public
 - plan/docs here should not reference private repo names or private implementation details
 
+### 5. Current-wave proof gates on CLI, Python SDK, and core parser tests, with raw REST as supporting debug
+
+Reason:
+
+- the public validation surface should be able to stand on its own before QA drops to lower-level tooling
+- CLI, Python SDK, and parser tests can be named precisely in the plan instead of treating `SDK/CLI/TUI/MCP` as one generic bucket
+- raw REST still matters for backend-only debugging, but it should not hide missing functionality in the public validation surface
+- later stages should not over-credit TUI or MCP before they reach contract parity
+
+### 6. A validation surface only counts as backend-isolation proof if it shows explicit request parameters plus ordered stream detail
+
+Reason:
+
+- final-response-only output is not enough to localize reasoning, tool-progress, or event-order failures
+- the minimum current-wave proof contract is explicit `thinking` request visibility plus ordered evidence for reasoning deltas, text deltas, tool-call start, tool-call argument deltas, tool-call output, and terminal/error status
+- when a human or QA agent would naturally use the CLI/SDK first, the plan should upgrade that surface until it can carry the proof rather than routing around it with bespoke raw-REST code
+- if a provider emits something outside that normalized set, the surface should expose it as unknown/raw rather than silently dropping it
+
+### 7. TUI and MCP are deferred from the current validation gate until they can send explicit `thinking` and surface the minimum ordered-event contract
+
+Reason:
+
+- current heads still send `thinking: None` on those surfaces
+- treating them as equivalent to raw REST, Python SDK, or CLI would create false confidence
+- they can be promoted later once parity is implemented and proven
+
 ## Open Questions
 
-- Which exact structured reasoning/tool-progress events should be exposed as first-class public SDK/TUI/MCP surfaces in v1?
+- Once TUI and MCP reach request/stream parity, should they become same-wave gating surfaces or remain optional supporting probes?
+- Which additional normalized event families beyond the current minimum contract are worth first-class public exposure after v1 parity lands?
 
 ## Evidence Used
 

--- a/docs/exec-plans/active/otto-validation-surface/DECISIONS.md
+++ b/docs/exec-plans/active/otto-validation-surface/DECISIONS.md
@@ -1,0 +1,50 @@
+# Otto Validation Surface Decisions
+
+## Resolved Decisions
+
+### 1. `ascend-tools` is a supplemental validation layer, not a browser replacement
+
+Reason:
+
+- text-native surfaces are faster for agents and humans to inspect
+- browser/UI proof is still needed for final user-visible behavior
+
+### 2. The repo should expose explicit thinking selection
+
+Reason:
+
+- validation is strongest when request inputs are explicit, not inferred
+- this keeps the public contract aligned with the coordinated workspace wave
+
+### 3. Structured stream surfaces matter as much as final responses
+
+Reason:
+
+- backend-isolation work requires visibility into reasoning and tool progress, not only terminal message text
+- coarse text-only streaming is not enough to distinguish backend vs consumer bugs
+
+### 4. Public docs must stay repo-local and generic
+
+Reason:
+
+- this repo is public
+- plan/docs here should not reference private repo names or private implementation details
+
+## Open Questions
+
+- Which exact structured reasoning/tool-progress events should be exposed as first-class public SDK/TUI/MCP surfaces in v1?
+
+## Evidence Used
+
+- `AGENTS.md`
+- `ARCHITECTURE.md`
+- `docs/DEVELOPMENT.md`
+- `tests/README.md`
+- `crates/ascend-tools-core/src/models.rs`
+- `crates/ascend-tools-core/src/client.rs`
+- `crates/ascend-tools-tui/src/lib.rs`
+- `tests/integration.py`
+
+## Needs Human Input
+
+None at this repo-local scope.

--- a/docs/exec-plans/active/otto-validation-surface/IMPLEMENTATION.md
+++ b/docs/exec-plans/active/otto-validation-surface/IMPLEMENTATION.md
@@ -12,10 +12,10 @@
 - `crates/ascend-tools-mcp/src/server.rs`
 - `crates/ascend-tools-py/src/lib.rs`
 - `crates/ascend-tools-js/src/lib.rs`
-- `tests/rest.py`
 - `tests/rest.js`
 - `tests/integration.py`
 - `tests/integration.sh`
+- `crates/ascend-tools-core/tests/client_http.rs`
 - relevant public docs under `docs/`
 
 ## Boundary Contracts
@@ -43,10 +43,14 @@ The public Otto streaming surface should expose enough structured events to supp
 - tool-call output
 - terminal status / error
 
+For the current wave, that contract must be available through the CLI itself, not only through direct raw REST scripts.
+
 ### 3. Surface layering
 
-- raw REST scripts validate the backend contract directly
-- SDK/CLI/TUI/MCP validate this repo's translation / exposure layer
+- CLI is the current-wave higher-level ordered-event proof surface for this repo's translation / exposure layer
+- Python SDK is a current-wave request-contract surface and should be explicit about any ordered-event limitations
+- raw REST scripts validate the backend contract directly and remain a debugging fallback rather than a substitute for missing CLI/SDK capabilities
+- TUI and MCP are follow-up surfaces until they can send explicit `thinking` and expose the minimum ordered-event contract
 - downstream browser/UIs remain separate consumers outside this repo's contract
 
 ## Ordered Phases
@@ -54,16 +58,18 @@ The public Otto streaming surface should expose enough structured events to supp
 ### Phase 1: Request widening
 
 - extend the Otto request model to carry explicit thinking-level selection
-- thread that selection through CLI, SDK, TUI, and MCP entrypoints as appropriate
+- thread that selection through the current-wave gating surfaces first (raw REST asset, Python SDK, and CLI), then widen TUI/MCP if they are kept in scope
 
 ### Phase 2: Streaming event widening
 
 - expand the structured event model beyond text deltas and coarse tool-call events where needed
-- ensure TUI/CLI/SDK/MCP consumers can inspect the new behavior without needing a browser
+- ensure the CLI can inspect the widened behavior without needing a browser, and do not credit TUI/MCP until they reach the same minimum contract
 
 ### Phase 3: Validation assets
 
-- add or extend raw REST and integration tests so they can prove backend behavior independently of a browser consumer
+- add or extend CLI/SDK validation assets so they can prove higher-level behavior independently of a browser consumer
+- keep raw REST available for backend-only debugging when CLI/SDK evidence reveals a discrepancy
+- keep validation assets explicit about which surfaces are merge-gating now versus deferred follow-up
 - keep the separation clear between backend failures and `ascend-tools`-layer failures
 
 ### Phase 4: Public docs
@@ -80,5 +86,6 @@ The public Otto streaming surface should expose enough structured events to supp
 ## Review-Readiness Conditions
 
 - The request and stream contracts are explicit enough for later agents or humans to use for debugging
+- The current-wave gate is explicit about which surfaces count now and which remain deferred
 - The repo can help distinguish backend failures from downstream consumer failures
 - Public docs remain free of private-repo references

--- a/docs/exec-plans/active/otto-validation-surface/IMPLEMENTATION.md
+++ b/docs/exec-plans/active/otto-validation-surface/IMPLEMENTATION.md
@@ -1,0 +1,84 @@
+# Otto Validation Surface Implementation
+
+## Repos And Surfaces In Scope
+
+### Primary repo: `ascend-tools`
+
+- `crates/ascend-tools-core/src/models.rs`
+- `crates/ascend-tools-core/src/client.rs`
+- `crates/ascend-tools-core/src/sse.rs`
+- `crates/ascend-tools-cli/src/otto.rs`
+- `crates/ascend-tools-tui/src/lib.rs`
+- `crates/ascend-tools-mcp/src/server.rs`
+- `crates/ascend-tools-py/src/lib.rs`
+- `crates/ascend-tools-js/src/lib.rs`
+- `tests/rest.py`
+- `tests/rest.js`
+- `tests/integration.py`
+- `tests/integration.sh`
+- relevant public docs under `docs/`
+
+## Boundary Contracts
+
+### 1. Request contract
+
+The public Otto request surface in this repo should be able to carry:
+
+- prompt
+- runtime/deployment/workspace target
+- model selection
+- explicit thinking level
+- conversation/thread continuation
+
+This repo should not guess or hide the thinking selection once the explicit contract exists.
+
+### 2. Stream event contract
+
+The public Otto streaming surface should expose enough structured events to support backend isolation:
+
+- text delta
+- reasoning/thinking progress when emitted
+- tool-call start
+- progressive tool-call argument updates when emitted
+- tool-call output
+- terminal status / error
+
+### 3. Surface layering
+
+- raw REST scripts validate the backend contract directly
+- SDK/CLI/TUI/MCP validate this repo's translation / exposure layer
+- downstream browser/UIs remain separate consumers outside this repo's contract
+
+## Ordered Phases
+
+### Phase 1: Request widening
+
+- extend the Otto request model to carry explicit thinking-level selection
+- thread that selection through CLI, SDK, TUI, and MCP entrypoints as appropriate
+
+### Phase 2: Streaming event widening
+
+- expand the structured event model beyond text deltas and coarse tool-call events where needed
+- ensure TUI/CLI/SDK/MCP consumers can inspect the new behavior without needing a browser
+
+### Phase 3: Validation assets
+
+- add or extend raw REST and integration tests so they can prove backend behavior independently of a browser consumer
+- keep the separation clear between backend failures and `ascend-tools`-layer failures
+
+### Phase 4: Public docs
+
+- document how to use these surfaces for Otto validation and debugging
+- keep the wording generic and public-repo-safe
+
+## Allowed Change Boundaries
+
+- Otto request/streaming surfaces in this repo
+- validation assets in `tests/`
+- public-facing docs in this repo
+
+## Review-Readiness Conditions
+
+- The request and stream contracts are explicit enough for later agents or humans to use for debugging
+- The repo can help distinguish backend failures from downstream consumer failures
+- Public docs remain free of private-repo references

--- a/docs/exec-plans/active/otto-validation-surface/PLAN.md
+++ b/docs/exec-plans/active/otto-validation-surface/PLAN.md
@@ -7,10 +7,14 @@ Extend the `ascend-tools` Otto surfaces so they provide a fast, text-native vali
 ## Success Contract
 
 - `ascend-tools` can exercise Otto with explicit thinking levels, not only default behavior.
-- The SDK/CLI/TUI/MCP surfaces expose enough structured stream information to validate reasoning and tool-call progress without going straight to a browser.
+- CLI (`tests/integration.sh` plus `ascend-tools otto run --jsonl`) is the current-wave public proof surface for exact request provenance and ordered stream inspection.
+- Python SDK (`tests/integration.py`) remains a current-wave request-contract surface, but it does not substitute for ordered-event proof until it exposes the same minimum contract.
+- Raw REST (`tests/rest.js`) is a supporting debug surface for backend isolation, not a substitute for missing CLI/SDK validation capabilities.
+- At least one higher-level public validation surface preserves ordered event inspection plus provenance metadata (`base URL`, provider, model, explicit `thinking`, thread/request identifiers, and terminal status) so the browser is not the first place a human has to inspect payload order.
+- TUI and MCP only count in the current wave if they can send explicit `thinking` and expose the same minimum ordered-event contract; otherwise they remain explicit follow-up surfaces rather than implicit proof.
 - Validation assets in this repo can help isolate whether a failure belongs to:
   - the backend contract
-  - the `ascend-tools` SDK/CLI/TUI/MCP layer
+  - the `ascend-tools` request/stream surface in use
   - a downstream UI consumer
 - This repo supplements browser/UI testing rather than trying to replace it.
 
@@ -32,12 +36,14 @@ Extend the `ascend-tools` Otto surfaces so they provide a fast, text-native vali
 ## Current State
 
 - `ascend-tools` already has:
-  - raw REST validation scripts
-  - SDK and CLI integration tests
-  - a TUI
-  - streaming support for text deltas and tool call start/output
-- `ascend-tools` does not yet appear to expose structured streamed reasoning events or progressive tool-call argument deltas as first-class validation surfaces.
-- The Otto request surface in this repo is still minimal compared with the explicit thinking-level contract being adopted in the coordinated workspace wave.
+  - a raw REST Otto SSE asset in `tests/rest.js`
+  - a Python SDK integration asset in `tests/integration.py`
+  - a CLI integration asset in `tests/integration.sh`
+  - deterministic request/stream parser tests in `crates/ascend-tools-core/tests/client_http.rs`
+  - a TUI and MCP surface
+- `tests/rest.py` is not the Otto streaming proof asset for this workspace wave.
+- The current heads widened request support and now add a structured CLI `--jsonl` path for raw ordered Otto updates; TUI and MCP still send `thinking: None` and therefore are not current-wave gating proof surfaces until widened.
+- Raw REST remains valuable for lower-level debugging, but the repo should reject "implementation complete" if CLI/SDK surfaces still cannot show the exact request/provenance and ordered events QA needs.
 
 ## Actor / Role Matrix
 
@@ -49,10 +55,10 @@ Extend the `ascend-tools` Otto surfaces so they provide a fast, text-native vali
 
 ## Execution Phases
 
-1. Define the public Otto validation contract this repo should expose
-2. Extend request and streaming surfaces where needed
-3. Add validation assets that isolate backend vs consumer issues
-4. Document the supported debugging / validation workflow
+1. Define the minimum public Otto validation contract this repo should expose, including which surfaces are current-wave gating versus deferred follow-up.
+2. Extend request and streaming surfaces where needed.
+3. Add validation assets that prove explicit `thinking` serialization, ordered event families, terminal classification, and cross-surface parity.
+4. Document the supported debugging / validation workflow, including provenance and environment-authority expectations.
 
 ## Plan Deltas
 
@@ -67,6 +73,7 @@ None at this repo-local scope.
 ## Deferred / Follow-up Work
 
 - Richer conversation/thread inspection helpers if later debugging needs them
+- Explicit `thinking` plus ordered-event parity for TUI and MCP if they are brought into the validation gate later
 - Additional structured event surfaces beyond the minimum needed for Otto validation
 - Broader tutorial/demo material once the validation contract stabilizes
 

--- a/docs/exec-plans/active/otto-validation-surface/PLAN.md
+++ b/docs/exec-plans/active/otto-validation-surface/PLAN.md
@@ -1,0 +1,75 @@
+# Otto Validation Surface
+
+## Objective
+
+Extend the `ascend-tools` Otto surfaces so they provide a fast, text-native validation and debugging layer for streamed reasoning, tool-call progress, and stream lifecycle behavior, making it easier to distinguish backend contract issues from consumer-UI issues.
+
+## Success Contract
+
+- `ascend-tools` can exercise Otto with explicit thinking levels, not only default behavior.
+- The SDK/CLI/TUI/MCP surfaces expose enough structured stream information to validate reasoning and tool-call progress without going straight to a browser.
+- Validation assets in this repo can help isolate whether a failure belongs to:
+  - the backend contract
+  - the `ascend-tools` SDK/CLI/TUI/MCP layer
+  - a downstream UI consumer
+- This repo supplements browser/UI testing rather than trying to replace it.
+
+## Scope
+
+- Otto request model in `ascend-tools-core`
+- Otto streaming event model and SSE dispatch in `ascend-tools-core`
+- Otto CLI/TUI/SDK/MCP surfaces that expose request selection or stream behavior
+- Integration and raw-REST validation assets under `tests/`
+- Public docs that explain how to use these surfaces for Otto validation
+
+## Non-goals
+
+- Reproducing a downstream UI's exact visual behavior inside `ascend-tools`
+- Replacing browser/UI testing as the final proof for user-visible behavior
+- Encoding private-repo implementation details into this public repo's docs
+- Becoming the source of truth for provider-specific product semantics outside the `ascend-tools` API surface
+
+## Current State
+
+- `ascend-tools` already has:
+  - raw REST validation scripts
+  - SDK and CLI integration tests
+  - a TUI
+  - streaming support for text deltas and tool call start/output
+- `ascend-tools` does not yet appear to expose structured streamed reasoning events or progressive tool-call argument deltas as first-class validation surfaces.
+- The Otto request surface in this repo is still minimal compared with the explicit thinking-level contract being adopted in the coordinated workspace wave.
+
+## Actor / Role Matrix
+
+| Actor | Goal | Relevant behavior |
+| --- | --- | --- |
+| Engineer or agent debugging Otto | Quickly determine whether an Otto failure is backend-side before escalating to browser/UI proof | Uses raw REST, SDK, CLI, TUI, or MCP surfaces |
+| SDK/CLI/TUI maintainer | Keep public Otto surfaces aligned with the real backend contract | Adds request fields, streaming events, and docs/tests |
+| Reviewer | Verify that `ascend-tools` accelerates debugging without claiming to replace end-to-end UI proof | Checks contract clarity, tests, and public-doc honesty |
+
+## Execution Phases
+
+1. Define the public Otto validation contract this repo should expose
+2. Extend request and streaming surfaces where needed
+3. Add validation assets that isolate backend vs consumer issues
+4. Document the supported debugging / validation workflow
+
+## Plan Deltas
+
+- Promote `ascend-tools` from implicit supporting repo to explicit active plan root in the coordinated workspace wave.
+- Treat this repo as a backend-isolation and validation surface, not just a generic SDK/CLI package.
+- Keep the plan public-repo-safe by describing downstream consumers generically rather than naming private repos.
+
+## Needs Human Input
+
+None at this repo-local scope.
+
+## Deferred / Follow-up Work
+
+- Richer conversation/thread inspection helpers if later debugging needs them
+- Additional structured event surfaces beyond the minimum needed for Otto validation
+- Broader tutorial/demo material once the validation contract stabilizes
+
+## Execution Log
+
+- 2026-03-28: Created the initial ASE plan root for the public `ascend-tools` repo as part of the coordinated Otto validation workspace wave.

--- a/docs/exec-plans/active/otto-validation-surface/PRODUCT.md
+++ b/docs/exec-plans/active/otto-validation-surface/PRODUCT.md
@@ -1,0 +1,56 @@
+# Otto Validation Surface Product Contract
+
+## User Value
+
+`ascend-tools` should give engineers and agents a faster, more readable Otto validation surface than a browser alone, while still staying public-repo-safe and avoiding downstream UI assumptions.
+
+The repo should let a user:
+
+- invoke Otto with explicit model and thinking selections
+- observe streamed text, reasoning/tool progress, and stream terminal state
+- validate backend behavior using raw REST, SDK, CLI, TUI, or MCP surfaces
+
+## Actors
+
+| Actor | Job to be done |
+| --- | --- |
+| Engineer or agent debugging Otto | Isolate whether a failure belongs to the backend contract or to a downstream UI consumer |
+| CLI/TUI user | Run Otto quickly from a terminal and inspect structured stream behavior |
+| SDK/MCP consumer | Build higher-level validation or automation on top of a structured Otto surface |
+
+## Primary Journeys
+
+### Journey 1: Raw backend check
+
+1. User runs a raw REST validation script.
+2. User verifies whether the backend itself already returns the wrong data.
+3. If raw REST fails, the issue is backend-side.
+
+### Journey 2: SDK/CLI/TUI check
+
+1. User runs the Otto flow through `ascend-tools`.
+2. User inspects streamed text, tool-call progress, and thinking-related signals.
+3. If raw REST passes but `ascend-tools` fails, the issue is in this repo's contract layer.
+
+### Journey 3: Downstream UI escalation
+
+1. Raw REST and `ascend-tools` both behave correctly.
+2. The downstream consumer still misbehaves.
+3. The remaining issue is likely browser/UI-specific rather than backend-contract-specific.
+
+## Visible / Exposed Contract
+
+`ascend-tools` should expose enough Otto behavior to support debugging and validation in text-native surfaces:
+
+- explicit model selection
+- explicit thinking-level selection
+- streamed text deltas
+- tool-call start/output details
+- progressive tool-call argument visibility when available
+- stream terminal status and error classification
+
+## Non-goals
+
+- Reproducing a downstream UI's exact presentation
+- Serving as the final proof layer for user-visible UX
+- Depending on private-repo documentation or implementation details

--- a/docs/exec-plans/active/otto-validation-surface/PRODUCT.md
+++ b/docs/exec-plans/active/otto-validation-surface/PRODUCT.md
@@ -8,7 +8,7 @@ The repo should let a user:
 
 - invoke Otto with explicit model and thinking selections
 - observe streamed text, reasoning/tool progress, and stream terminal state
-- validate backend behavior using raw REST, SDK, CLI, TUI, or MCP surfaces
+- validate backend behavior first through the public CLI/SDK surfaces, using raw REST only as a lower-level debugging fallback
 
 ## Actors
 
@@ -20,21 +20,21 @@ The repo should let a user:
 
 ## Primary Journeys
 
-### Journey 1: Raw backend check
+### Journey 1: Public-surface check
 
-1. User runs a raw REST validation script.
+1. User runs the Otto flow through the CLI or SDK.
+2. User inspects the exact request/provenance plus streamed text, tool-call progress, and thinking-related signals.
+3. If the public surface cannot expose enough detail for that inspection, the implementation is incomplete.
+
+### Journey 2: Raw backend comparison
+
+1. User runs a raw REST validation script after the public surface already showed a discrepancy or needs lower-level isolation.
 2. User verifies whether the backend itself already returns the wrong data.
-3. If raw REST fails, the issue is backend-side.
-
-### Journey 2: SDK/CLI/TUI check
-
-1. User runs the Otto flow through `ascend-tools`.
-2. User inspects streamed text, tool-call progress, and thinking-related signals.
 3. If raw REST passes but `ascend-tools` fails, the issue is in this repo's contract layer.
 
 ### Journey 3: Downstream UI escalation
 
-1. Raw REST and `ascend-tools` both behave correctly.
+1. `ascend-tools` behaves correctly and any supporting raw REST comparison agrees.
 2. The downstream consumer still misbehaves.
 3. The remaining issue is likely browser/UI-specific rather than backend-contract-specific.
 
@@ -44,10 +44,14 @@ The repo should let a user:
 
 - explicit model selection
 - explicit thinking-level selection
+- provenance metadata sufficient to prove what was exercised (`base URL` or instance, provider, model, explicit `thinking`, and thread/request identifiers where available)
 - streamed text deltas
+- reasoning-delta visibility
 - tool-call start/output details
 - progressive tool-call argument visibility when available
 - stream terminal status and error classification
+- at least one ordered event-inspection path that can show the same turn as a sequence rather than only a final response summary
+- explicit unknown/raw-event surfacing when a provider emits a family that the normalized surface does not yet understand, so validation surfaces do not silently drop evidence
 
 ## Non-goals
 

--- a/docs/exec-plans/active/otto-validation-surface/VALIDATION.md
+++ b/docs/exec-plans/active/otto-validation-surface/VALIDATION.md
@@ -2,55 +2,99 @@
 
 ## Validation Goals
 
-- Prove `ascend-tools` can carry explicit thinking selection through its Otto request surfaces
-- Prove `ascend-tools` exposes enough stream information to help isolate backend vs consumer failures
-- Prove raw REST and higher-level SDK/CLI/TUI/MCP paths tell a coherent debugging story
+- Prove `ascend-tools` can carry explicit thinking selection through its current-wave Otto request surfaces.
+- Prove the CLI preserves enough ordered stream evidence and request provenance to isolate reasoning/tool-progress failures before a human has to open the browser.
+- Prove raw REST remains only a supporting/debugging layer rather than the primary substitute for a missing public validation surface.
+- Prove the CLI and any supporting lower-level surface tell a coherent debugging story for the same prompt family.
+- Keep TUI and MCP honest: they only receive current-wave proof credit if they can send explicit `thinking` and expose the minimum ordered-event contract.
+- Prove environment authority and provenance are recorded so mis-targeted runs do not masquerade as product regressions.
 
 ## Validation Matrix
 
-| Scenario | What must be true |
-| --- | --- |
-| Raw REST check | backend behavior can be exercised without SDK dependency |
-| SDK check | public SDK surface preserves the intended Otto request and response contract |
-| CLI check | CLI can issue the relevant Otto requests and report useful output |
-| TUI check | streamed behavior is inspectable in a text-native UI |
-| Thinking selection | explicit thinking level can be passed through request surfaces |
-| Tool progress | tool-call progress is exposed well enough to support backend isolation |
+| Surface / asset | What must be true now | Current-wave gate |
+| --- | --- | --- |
+| Raw REST (`tests/rest.js`) | exact request payload and raw SSE events remain available for backend-only debugging, but this path does not replace missing CLI/SDK proof | supporting only |
+| Python SDK (`tests/integration.py`) | public SDK preserves request fields and the final response contract; if stream-order visibility is absent, the limitation is recorded explicitly | required for request contract; not sufficient alone for ordered-event proof |
+| CLI (`tests/integration.sh` and `ascend-tools otto run ... --jsonl`) | explicit `thinking` reaches the request, request provenance is visible, raw ordered event families are preserved, and terminal status/error is machine-checkable | required |
+| CLI one-shot completion semantics | a one-shot `otto run` exits cleanly when the first `thread.details` / thread snapshot already shows `is_processing=false`, instead of hanging on heartbeat pings | required |
+| Core parser (`crates/ascend-tools-core/tests/client_http.rs`) | deterministic request serialization, ordered event-family parsing, terminal classification, and interruption handling remain correct | required |
+| TUI (`crates/ascend-tools-tui/src/lib.rs`) | only counts after explicit `thinking` and the minimum ordered-event contract are implemented | deferred |
+| MCP (`crates/ascend-tools-mcp/src/server.rs`) | only counts after explicit `thinking` and the minimum ordered-event contract are implemented | deferred |
 
 ## Local Validation Gate
 
 - `bin/check`
-- targeted Rust tests for Otto request/stream behavior
-- targeted integration tests under `tests/`
+- targeted Rust tests for Otto request/stream behavior in `crates/ascend-tools-core/tests/client_http.rs`
+- `node tests/rest.js`
+- `uv run --script tests/integration.py`
+- `bash tests/integration.sh`
+
+## Environment Authority / Provenance
+
+- Record the base URL or instance being exercised, the workspace/runtime identity, provider, model, explicit `thinking` value, and resulting thread/request identifiers.
+- Record whether the command used the current workspace binary or an installed binary.
+- When comparing surfaces, use the same prompt family and preserve that provenance across CLI, SDK, any supporting raw REST probe, and any later browser proof.
+- If a surface cannot echo enough provenance to prove what it exercised, do not count it as full proof for isolation decisions.
+- If QA has to drop to direct raw REST because the CLI still cannot show exact request payloads or ordered events, treat that as an implementation gap rather than successful validation.
 
 ## Manual Scenarios
 
 ### 1. Raw REST path
 
-- Use `tests/rest.py` or `tests/rest.js`
-- Verify the backend contract directly
+- Use `tests/rest.js`
+- Use it only after the public surface has already been exercised or when debugging a discrepancy.
+- Verify the backend contract directly with:
+  - explicit `thinking` selection
+  - ordered SSE event names
+  - terminal event or error classification
+  - recorded thread/provenance metadata
 
 ### 2. SDK path
 
 - Use `tests/integration.py`
 - Verify SDK request/response behavior
+- If the SDK path does not expose ordered stream detail, record that limitation explicitly instead of crediting it for stream-order proof
 
 ### 3. CLI path
 
 - Use `tests/integration.sh`
-- Verify CLI request flow and output shape
+- Use `ascend-tools otto run ... --jsonl`
+- Verify CLI request flow, explicit `thinking`, request provenance output, raw ordered event payloads, thread identifiers, and terminal status/error
+- Include at least one substantial prompt that predictably exercises reasoning and/or tool use; do not treat `ping`-class prompts as sufficient coverage for streaming correctness by themselves
+- Verify the one-shot command exits correctly when the updates stream starts with a completed thread snapshot instead of a later `thread.done`
 
-### 4. TUI / streaming path
+### 4. Cross-surface parity
 
-- Run `ascend-tools otto tui`
-- Verify that streamed behavior remains inspectable without a browser
+- Run the same prompt family through the CLI first, then add raw REST only if lower-level isolation is needed
+- Verify request parameters, ordered event families, terminal status, and persisted identifiers tell the same story before using the browser as the next debugging surface
+- At least one shared prompt family must be non-trivial enough to force the brittle path under review, for example reasoning plus tool use or larger streamed output rather than a short final-only answer
+
+### 5. Error and terminal-state path
+
+- Exercise one invalid or unsupported thinking selection
+- Exercise one interrupted or `response.error` path
+- Verify the chosen surface exposes a structured failure or terminal classification instead of collapsing everything to opaque final text
+
+### 6. Deferred surfaces honesty
+
+- Do not count TUI or MCP as current-wave validation gates until they can both send exact `thinking` values and expose the minimum ordered-event contract
+- If they are inspected anyway, record them as exploratory or follow-up evidence rather than merge-gating proof
 
 ## Rollout / Sequencing
 
 - This repo supplements downstream consumer testing; it does not replace it.
+- The CLI should be exercised before browser/UI debugging is treated as the next honest move.
+- Raw REST is a lower-level comparison tool after the CLI/SDK path, not the default proof path when the public validation surface is still underpowered.
+- Same-case parity across surfaces is a prerequisite for crediting `ascend-tools` as a backend-isolation layer.
+- TUI and MCP stay explicit follow-up surfaces unless their request and ordered-event parity is implemented and proven.
 - Keep docs generic and public-repo-safe.
 
 ## Stop Conditions
 
 - Stop if the repo still cannot distinguish backend contract failures from higher-level consumer failures.
+- Stop if the CLI cannot show the exact sent request payload or the ordered event families needed for the question.
+- Stop if the credited proof prompts are so trivial that they avoid the exact reasoning, tool-call, or larger-stream path that the human would obviously try next.
+- Stop if QA is relying on raw REST because the CLI/SDK surface still cannot reproduce the same prompt family with matching provenance.
+- Stop if a surface is being credited as proof even though it cannot show the exact sent `thinking` value or the ordered event families needed for the question.
+- Stop if the validation story depends on TUI or MCP while they still send `thinking: None`.
 - Stop if the added validation story depends on private-repo implementation details rather than public Otto contract behavior.

--- a/docs/exec-plans/active/otto-validation-surface/VALIDATION.md
+++ b/docs/exec-plans/active/otto-validation-surface/VALIDATION.md
@@ -1,0 +1,56 @@
+# Otto Validation Surface Validation
+
+## Validation Goals
+
+- Prove `ascend-tools` can carry explicit thinking selection through its Otto request surfaces
+- Prove `ascend-tools` exposes enough stream information to help isolate backend vs consumer failures
+- Prove raw REST and higher-level SDK/CLI/TUI/MCP paths tell a coherent debugging story
+
+## Validation Matrix
+
+| Scenario | What must be true |
+| --- | --- |
+| Raw REST check | backend behavior can be exercised without SDK dependency |
+| SDK check | public SDK surface preserves the intended Otto request and response contract |
+| CLI check | CLI can issue the relevant Otto requests and report useful output |
+| TUI check | streamed behavior is inspectable in a text-native UI |
+| Thinking selection | explicit thinking level can be passed through request surfaces |
+| Tool progress | tool-call progress is exposed well enough to support backend isolation |
+
+## Local Validation Gate
+
+- `bin/check`
+- targeted Rust tests for Otto request/stream behavior
+- targeted integration tests under `tests/`
+
+## Manual Scenarios
+
+### 1. Raw REST path
+
+- Use `tests/rest.py` or `tests/rest.js`
+- Verify the backend contract directly
+
+### 2. SDK path
+
+- Use `tests/integration.py`
+- Verify SDK request/response behavior
+
+### 3. CLI path
+
+- Use `tests/integration.sh`
+- Verify CLI request flow and output shape
+
+### 4. TUI / streaming path
+
+- Run `ascend-tools otto tui`
+- Verify that streamed behavior remains inspectable without a browser
+
+## Rollout / Sequencing
+
+- This repo supplements downstream consumer testing; it does not replace it.
+- Keep docs generic and public-repo-safe.
+
+## Stop Conditions
+
+- Stop if the repo still cannot distinguish backend contract failures from higher-level consumer failures.
+- Stop if the added validation story depends on private-repo implementation details rather than public Otto contract behavior.

--- a/docs/exec-plans/completed/README.md
+++ b/docs/exec-plans/completed/README.md
@@ -1,0 +1,7 @@
+# Completed Execution Plans
+
+Historical record of completed work plans.
+
+## Index
+
+_None yet._

--- a/tests/app/package-lock.json
+++ b/tests/app/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../../crates/ascend-tools-js": {
       "name": "ascend-tools",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "bin": {
         "ascend-tools": "cli.js"

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -83,6 +83,55 @@ def run_flow_with_retry(
     raise RuntimeError("run_flow retry exhausted")
 
 
+def run_otto_with_retry(
+    client: Client,
+    *,
+    workspace: str,
+    prompt: str,
+    model: str | None = None,
+    thinking: str | None = None,
+) -> dict:
+    """Run Otto with retries for paused or still-starting local workspaces."""
+    last_error: Exception | None = None
+    for delay in (0, 2, 5, 10, 15):
+        if delay:
+            time.sleep(delay)
+        try:
+            kwargs = {"prompt": prompt, "workspace": workspace}
+            if model is not None:
+                kwargs["model"] = model
+            if thinking is not None:
+                kwargs["thinking"] = thinking
+            return client.otto(**kwargs)
+        except Exception as e:  # noqa: BLE001
+            msg = str(e).lower()
+            if "paused" in msg:
+                client.resume_workspace(title=workspace)
+                last_error = e
+                continue
+            if "starting" in msg or "no health status" in msg or "initializing" in msg:
+                last_error = e
+                continue
+            raise
+
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("otto retry exhausted")
+
+
+def pick_reasoning_model(providers: list[dict]) -> str | None:
+    for provider in providers:
+        for model in provider.get("models", []):
+            model_id = model.get("id", "")
+            if any(
+                token in model_id.lower() for token in ("claude", "gpt-5", "gemini")
+            ):
+                return model_id
+            if model_id.lower().startswith("o"):
+                return model_id
+    return None
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="ascend-tools Python SDK integration tests"
@@ -229,11 +278,35 @@ def main():
 
     print("=== otto chat ===")
 
+    reasoning_model = None
+    if got.get("paused") is True:
+        resumed = client.resume_workspace(title=ws_title)
+        check(
+            resumed.get("paused") is False,
+            "resume_workspace clears paused before otto",
+        )
     try:
-        otto_resp = client.otto(prompt="ping", workspace=ws_title)
+        provider_probe = client.list_otto_providers()
+        if isinstance(provider_probe, list):
+            reasoning_model = pick_reasoning_model(provider_probe)
+    except Exception:
+        pass
+
+    try:
+        otto_resp = run_otto_with_retry(
+            client,
+            prompt="ping",
+            workspace=ws_title,
+            model=reasoning_model,
+            thinking="medium" if reasoning_model else None,
+        )
         check(isinstance(otto_resp, dict), "otto returns dict")
         check("message" in otto_resp, "otto response has 'message' key")
         check("thread_id" in otto_resp, "otto response has 'thread_id' key")
+        if reasoning_model:
+            check(True, f"otto accepts explicit thinking for {reasoning_model}")
+        else:
+            skip("no reasoning-capable otto model found for explicit thinking request")
     except Exception as e:  # noqa: BLE001
         msg = str(e).lower()
         if "not found" in msg or "not implemented" in msg or "404" in msg:
@@ -245,6 +318,7 @@ def main():
 
     print("=== otto provider ===")
 
+    providers = None
     try:
         providers = client.list_otto_providers()
         check(isinstance(providers, list), "list_otto_providers returns list")

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -22,6 +22,13 @@ from ascend_tools import Client
 PASS = 0
 FAIL = 0
 SKIP = 0
+FOUNDRY_SIMPLE_PROMPT = (
+    "Briefly explain what ASCEND_INSTANCE_API_URL is used for in one sentence."
+)
+OTTO_TOOL_PROMPT = (
+    "Use a tool to inspect the current workspace root, confirm whether the repo contains both "
+    "ascend-tools and ascend-backend, and answer in two short sentences with the names you found."
+)
 
 
 def check(condition: bool, label: str, detail: str = ""):
@@ -89,6 +96,7 @@ def run_otto_with_retry(
     workspace: str,
     prompt: str,
     model: str | None = None,
+    provider: str | None = None,
     thinking: str | None = None,
 ) -> dict:
     """Run Otto with retries for paused or still-starting local workspaces."""
@@ -100,6 +108,8 @@ def run_otto_with_retry(
             kwargs = {"prompt": prompt, "workspace": workspace}
             if model is not None:
                 kwargs["model"] = model
+            if provider is not None:
+                kwargs["provider"] = provider
             if thinking is not None:
                 kwargs["thinking"] = thinking
             return client.otto(**kwargs)
@@ -130,6 +140,58 @@ def pick_reasoning_model(providers: list[dict]) -> str | None:
             if model_id.lower().startswith("o"):
                 return model_id
     return None
+
+
+def find_provider_model(
+    providers: list[dict], provider_id: str, model_id: str
+) -> str | None:
+    for provider in providers:
+        if provider.get("id") != provider_id:
+            continue
+        for model in provider.get("models", []):
+            if model.get("id") == model_id:
+                return model_id
+    return None
+
+
+def exercise_otto_response_contract(
+    client: Client,
+    *,
+    workspace: str,
+    prompt: str,
+    label: str,
+    model: str | None = None,
+    provider: str | None = None,
+    allow_explicit_failure: bool = False,
+) -> bool:
+    try:
+        otto_resp = run_otto_with_retry(
+            client,
+            prompt=prompt,
+            workspace=workspace,
+            model=model,
+            provider=provider,
+            thinking="medium",
+        )
+        check(isinstance(otto_resp, dict), f"{label} returns dict")
+        check("message" in otto_resp, f"{label} response has 'message' key")
+        check("thread_id" in otto_resp, f"{label} response has 'thread_id' key")
+        check(
+            bool(str(otto_resp.get("message", "")).strip()),
+            f"{label} returned assistant output",
+            repr(otto_resp.get("message")),
+        )
+        return True
+    except Exception as e:  # noqa: BLE001
+        if allow_explicit_failure:
+            check(
+                bool(str(e).strip()),
+                f"{label} surfaced explicit failure",
+                str(e),
+            )
+            return False
+        check(False, label, str(e))
+        return False
 
 
 def main():
@@ -279,6 +341,7 @@ def main():
     print("=== otto chat ===")
 
     reasoning_model = None
+    foundry_gpt54_model = None
     if got.get("paused") is True:
         resumed = client.resume_workspace(title=ws_title)
         check(
@@ -289,30 +352,45 @@ def main():
         provider_probe = client.list_otto_providers()
         if isinstance(provider_probe, list):
             reasoning_model = pick_reasoning_model(provider_probe)
+            foundry_gpt54_model = find_provider_model(
+                provider_probe, "microsoft_foundry", "azure_ai/gpt-5.4"
+            )
     except Exception:
         pass
 
-    try:
-        otto_resp = run_otto_with_retry(
+    if foundry_gpt54_model:
+        exercise_otto_response_contract(
             client,
-            prompt="ping",
             workspace=ws_title,
-            model=reasoning_model,
-            thinking="medium" if reasoning_model else None,
+            prompt=FOUNDRY_SIMPLE_PROMPT,
+            label="foundry gpt-5.4 simple prompt",
+            model=foundry_gpt54_model,
+            provider="microsoft_foundry",
+            allow_explicit_failure=True,
         )
-        check(isinstance(otto_resp, dict), "otto returns dict")
-        check("message" in otto_resp, "otto response has 'message' key")
-        check("thread_id" in otto_resp, "otto response has 'thread_id' key")
-        if reasoning_model:
+        exercise_otto_response_contract(
+            client,
+            workspace=ws_title,
+            prompt=OTTO_TOOL_PROMPT,
+            label="foundry gpt-5.4 tool prompt",
+            model=foundry_gpt54_model,
+            provider="microsoft_foundry",
+            allow_explicit_failure=True,
+        )
+    else:
+        skip("foundry gpt-5.4 model not available for exact-path SDK probe")
+
+    if reasoning_model:
+        if exercise_otto_response_contract(
+            client,
+            workspace=ws_title,
+            prompt=OTTO_TOOL_PROMPT,
+            label=f"otto explicit thinking contract for {reasoning_model}",
+            model=reasoning_model,
+        ):
             check(True, f"otto accepts explicit thinking for {reasoning_model}")
-        else:
-            skip("no reasoning-capable otto model found for explicit thinking request")
-    except Exception as e:  # noqa: BLE001
-        msg = str(e).lower()
-        if "not found" in msg or "not implemented" in msg or "404" in msg:
-            skip(f"otto not available: {e}")
-        else:
-            check(False, "otto", str(e))
+    else:
+        skip("no reasoning-capable otto model found for explicit thinking request")
 
     # ---------- otto provider ----------
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -49,6 +49,51 @@ run_flow_retry() {
   return "$rc"
 }
 
+# Run `otto run` with retries for paused or still-starting local workspaces.
+run_otto_retry() {
+  local workspace_title="$1"
+  local model_id="$2"
+  local provider_id="${3:-}"
+
+  local out=""
+  local rc=1
+  local delay
+  for delay in 0 2 5 10 15; do
+    if [ "$delay" -gt 0 ]; then
+      sleep "$delay"
+    fi
+
+    set +e
+    if [ -n "$provider_id" ]; then
+      out=$($CLI otto run "ping" --workspace "$workspace_title" --provider "$provider_id" --model "$model_id" --thinking medium --jsonl 2>&1)
+    else
+      out=$($CLI otto run "ping" --workspace "$workspace_title" --model "$model_id" --thinking medium --jsonl 2>&1)
+    fi
+    rc=$?
+    set -e
+
+    if [ "$rc" -eq 0 ]; then
+      echo "$out"
+      return 0
+    fi
+
+    if echo "$out" | grep -qi "paused"; then
+      $CLI -o json workspace resume "$workspace_title" >/dev/null 2>&1 || true
+      continue
+    fi
+
+    if echo "$out" | grep -qi "starting\|no health status\|initializing"; then
+      continue
+    fi
+
+    echo "$out"
+    return "$rc"
+  done
+
+  echo "$out"
+  return "$rc"
+}
+
 # ---------- preflight ----------
 
 echo "=== preflight ==="
@@ -110,6 +155,8 @@ else
   fail "workspace get" "expected $RUNTIME_UUID, got $GOT_UUID"
 fi
 
+RUNTIME_PAUSED=$(echo "$GET_JSON" | jq -r '.paused')
+
 # verify expected fields
 for field in uuid id title kind project_uuid environment_uuid created_at updated_at; do
   VAL=$(echo "$GET_JSON" | jq -r ".$field")
@@ -170,6 +217,121 @@ if [ "$PROFILE_COUNT" -gt 0 ]; then
   pass "profile list returned $PROFILE_COUNT profile(s)"
 else
   skip "no profiles found"
+fi
+
+# ---------- otto ----------
+
+echo "=== otto ==="
+
+set +e
+OTTO_PROVIDERS_JSON=$($CLI -o json otto provider list 2>&1)
+OTTO_PROVIDERS_RC=$?
+set -e
+if [ "$OTTO_PROVIDERS_RC" -ne 0 ]; then
+  if echo "$OTTO_PROVIDERS_JSON" | grep -qi "not found\|not implemented\|404"; then
+    skip "otto provider list not available"
+  else
+    fail "otto provider list" "$OTTO_PROVIDERS_JSON"
+  fi
+else
+  pass "otto provider list returns JSON"
+  FOUNDRY_GPT54_MODEL=$(echo "$OTTO_PROVIDERS_JSON" | jq -r '
+    [
+      .[] | select(.id == "microsoft_foundry") | .models[]? | .id
+      | select(. == "azure_ai/gpt-5.4")
+    ][0] // empty
+  ')
+  OTTO_MODEL=$(echo "$OTTO_PROVIDERS_JSON" | jq -r '
+    [
+      .[] | .models[]? | .id
+      | select(test("(claude|gpt-5|gemini|^o[0-9])"; "i"))
+    ][0] // empty
+  ')
+
+  if [ -z "$OTTO_MODEL" ]; then
+    skip "no reasoning-capable otto model found for CLI thinking test"
+  else
+    echo "  using otto model: $OTTO_MODEL"
+    if [ "$RUNTIME_PAUSED" = "true" ]; then
+      PRE_OTTO_RESUME=$($CLI -o json workspace resume "$RUNTIME_TITLE" 2>&1)
+      PRE_OTTO_PAUSED=$(echo "$PRE_OTTO_RESUME" | jq -r '.paused')
+      if [ "$PRE_OTTO_PAUSED" = "false" ]; then
+        pass "workspace resume clears paused before otto"
+      else
+        fail "workspace resume before otto" "expected paused=false, got $PRE_OTTO_PAUSED"
+      fi
+    fi
+
+    if [ -n "$FOUNDRY_GPT54_MODEL" ]; then
+      set +e
+      FOUNDRY_OTTO_OUT=$(run_otto_retry "$RUNTIME_TITLE" "$FOUNDRY_GPT54_MODEL" "microsoft_foundry")
+      FOUNDRY_OTTO_RC=$?
+      set -e
+
+      if [ "$FOUNDRY_OTTO_RC" -ne 0 ]; then
+        fail "otto run foundry gpt-5.4 --thinking" "$FOUNDRY_OTTO_OUT"
+      else
+        if echo "$FOUNDRY_OTTO_OUT" | jq -e 'select(.record_type == "request") | .provider == "microsoft_foundry" and .model == "azure_ai/gpt-5.4"' >/dev/null; then
+          pass "foundry gpt-5.4 probe preserved provider/model provenance"
+        else
+          fail "foundry gpt-5.4 probe" "missing exact provider/model provenance"
+        fi
+
+        if echo "$FOUNDRY_OTTO_OUT" | jq -e 'select(.record_type == "terminal") | .stream_status == "completed"' >/dev/null; then
+          pass "foundry gpt-5.4 probe emitted completed terminal record"
+        else
+          fail "foundry gpt-5.4 probe" "missing completed terminal record"
+        fi
+
+        if echo "$FOUNDRY_OTTO_OUT" | jq -e 'select(.record_type == "event") | (.event_type == "response.reasoning_summary_text.delta" or .event_type == "response.reasoning_text.delta")' >/dev/null; then
+          pass "foundry gpt-5.4 probe surfaced reasoning events"
+        else
+          skip "foundry gpt-5.4 probe emitted no reasoning events"
+        fi
+      fi
+    else
+      skip "foundry gpt-5.4 model not available for exact-path probe"
+    fi
+
+    set +e
+    OTTO_RUN_OUT=$(run_otto_retry "$RUNTIME_TITLE" "$OTTO_MODEL")
+    OTTO_RUN_RC=$?
+    set -e
+
+    if [ "$OTTO_RUN_RC" -ne 0 ]; then
+      fail "otto run --thinking" "$OTTO_RUN_OUT"
+    else
+      if echo "$OTTO_RUN_OUT" | jq -e 'select(.record_type == "request") | .request_body.thinking == "medium"' >/dev/null; then
+        pass "otto run --jsonl preserves explicit thinking in request record"
+      else
+        fail "otto run --jsonl" "missing or incorrect thinking in request record"
+      fi
+
+      if echo "$OTTO_RUN_OUT" | jq -e 'select(.record_type == "event")' >/dev/null; then
+        pass "otto run --jsonl emitted ordered event records"
+      else
+        fail "otto run --jsonl" "missing event records"
+      fi
+
+      if echo "$OTTO_RUN_OUT" | jq -e 'select(.record_type == "terminal") | .stream_status == "completed"' >/dev/null; then
+        pass "otto run --jsonl emitted completed terminal record"
+      else
+        fail "otto run --jsonl" "missing completed terminal record"
+      fi
+
+      if echo "$OTTO_RUN_OUT" | jq -e 'select(.record_type == "event") | (.event_type == "response.reasoning_summary_text.delta" or .event_type == "response.reasoning_text.delta")' >/dev/null; then
+        pass "otto run --jsonl surfaced reasoning events"
+      else
+        skip "otto run --jsonl emitted no reasoning events for chosen model/prompt"
+      fi
+
+      if echo "$OTTO_RUN_OUT" | jq -e 'select(.record_type == "event") | .event_type == "response.function_call_arguments.delta"' >/dev/null; then
+        pass "otto run --jsonl surfaced tool argument deltas"
+      else
+        skip "otto run --jsonl emitted no tool argument deltas for chosen prompt"
+      fi
+    fi
+  fi
 fi
 
 # ---------- flows ----------

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -8,6 +8,7 @@ CLI="uv run ascend-tools"
 PASS=0
 FAIL=0
 SKIP=0
+LIGHTWEIGHT_FOLLOWUP_PROMPT="umm"
 FOUNDRY_SIMPLE_PROMPT="Briefly explain what ASCEND_INSTANCE_API_URL is used for in one sentence."
 OTTO_TOOL_PROMPT="Use a tool to inspect the current workspace root, confirm whether the repo contains both ascend-tools and ascend-backend, and answer in two short sentences with the names you found."
 
@@ -80,6 +81,15 @@ jsonl_has_tool_argument_deltas() {
   ' >/dev/null
 }
 
+provider_list_has_thinking_levels() {
+  echo "$1" | jq -e '
+    any(
+      .[];
+      any(.models[]?; has("thinking_levels"))
+    )
+  ' >/dev/null
+}
+
 # Run `flow run` with retries for transient readiness states.
 run_flow_retry() {
   local flow_name="$1"
@@ -122,6 +132,7 @@ run_otto_retry() {
   local model_id="$2"
   local prompt="$3"
   local provider_id="${4:-}"
+  local thread_id="${5:-}"
 
   local out=""
   local rc=1
@@ -133,9 +144,17 @@ run_otto_retry() {
 
     set +e
     if [ -n "$provider_id" ]; then
-      out=$($CLI otto run "$prompt" --workspace "$workspace_title" --provider "$provider_id" --model "$model_id" --thinking medium --jsonl 2>&1)
+      if [ -n "$thread_id" ]; then
+        out=$($CLI otto run "$prompt" --workspace "$workspace_title" --provider "$provider_id" --model "$model_id" --thinking medium --thread "$thread_id" --jsonl 2>&1)
+      else
+        out=$($CLI otto run "$prompt" --workspace "$workspace_title" --provider "$provider_id" --model "$model_id" --thinking medium --jsonl 2>&1)
+      fi
     else
-      out=$($CLI otto run "$prompt" --workspace "$workspace_title" --model "$model_id" --thinking medium --jsonl 2>&1)
+      if [ -n "$thread_id" ]; then
+        out=$($CLI otto run "$prompt" --workspace "$workspace_title" --model "$model_id" --thinking medium --thread "$thread_id" --jsonl 2>&1)
+      else
+        out=$($CLI otto run "$prompt" --workspace "$workspace_title" --model "$model_id" --thinking medium --jsonl 2>&1)
+      fi
     fi
     rc=$?
     set -e
@@ -303,6 +322,11 @@ if [ "$OTTO_PROVIDERS_RC" -ne 0 ]; then
   fi
 else
   pass "otto provider list returns JSON"
+  if provider_list_has_thinking_levels "$OTTO_PROVIDERS_JSON"; then
+    pass "otto provider list surfaces model thinking_levels"
+  else
+    fail "otto provider list" "missing model thinking_levels metadata"
+  fi
   FOUNDRY_GPT54_MODEL=$(echo "$OTTO_PROVIDERS_JSON" | jq -r '
     [
       .[] | select(.id == "microsoft_foundry") | .models[]? | .id
@@ -420,6 +444,33 @@ else
         pass "otto run --jsonl surfaced tool argument deltas for the tool-use prompt"
       else
         fail "otto run --jsonl" "missing tool argument deltas for the required tool-use prompt"
+      fi
+
+      OTTO_THREAD_ID=$(echo "$OTTO_RUN_OUT" | jq -r 'select(.record_type == "terminal") | .thread_id' | tail -n 1)
+      if [ -n "$OTTO_THREAD_ID" ] && [ "$OTTO_THREAD_ID" != "null" ]; then
+        pass "otto run --jsonl terminal record exposed thread_id"
+        set +e
+        OTTO_FOLLOWUP_OUT=$(run_otto_retry "$RUNTIME_TITLE" "$OTTO_MODEL" "$LIGHTWEIGHT_FOLLOWUP_PROMPT" "" "$OTTO_THREAD_ID")
+        OTTO_FOLLOWUP_RC=$?
+        set -e
+
+        if [ "$OTTO_FOLLOWUP_RC" -ne 0 ]; then
+          fail "otto follow-up --jsonl" "$OTTO_FOLLOWUP_OUT"
+        else
+          if echo "$OTTO_FOLLOWUP_OUT" | jq -e --arg thread_id "$OTTO_THREAD_ID" 'select(.record_type == "request") | .request_thread_id == $thread_id' >/dev/null; then
+            pass "otto follow-up --jsonl preserved request_thread_id"
+          else
+            fail "otto follow-up --jsonl" "missing request_thread_id on follow-up request"
+          fi
+
+          if echo "$OTTO_FOLLOWUP_OUT" | jq -e --arg thread_id "$OTTO_THREAD_ID" 'select(.record_type == "terminal") | .thread_id == $thread_id' >/dev/null; then
+            pass "otto follow-up --jsonl reused terminal thread_id"
+          else
+            fail "otto follow-up --jsonl" "terminal thread_id did not match follow-up target"
+          fi
+        fi
+      else
+        fail "otto run --jsonl" "terminal thread_id missing from initial turn"
       fi
     fi
   fi

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -8,10 +8,77 @@ CLI="uv run ascend-tools"
 PASS=0
 FAIL=0
 SKIP=0
+FOUNDRY_SIMPLE_PROMPT="Briefly explain what ASCEND_INSTANCE_API_URL is used for in one sentence."
+OTTO_TOOL_PROMPT="Use a tool to inspect the current workspace root, confirm whether the repo contains both ascend-tools and ascend-backend, and answer in two short sentences with the names you found."
 
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1 — $2"; FAIL=$((FAIL + 1)); }
 skip() { echo "  SKIP: $1"; SKIP=$((SKIP + 1)); }
+
+jsonl_completed_with_output() {
+  echo "$1" | jq -e -s '
+    def assistant_text:
+      [(.content // [])[]? | .text // .output_text // empty] | join("");
+    def completed_snapshot_has_text:
+      any(
+        .[];
+        .record_type == "event"
+        and .event_type == "thread.details"
+        and (.data.is_processing == false)
+        and (
+          (.data.messages | type == "object")
+          and any(
+            (.data.messages | to_entries[]?.value);
+            .role == "assistant" and (assistant_text | length > 0)
+          )
+        )
+      );
+    def has_text_delta:
+      any(
+        .[];
+        .record_type == "event"
+        and .event_type == "response.output_text.delta"
+        and ((.data.delta // "") | length > 0)
+      );
+    any(.[]; .record_type == "terminal" and .stream_status == "completed")
+    and (has_text_delta or completed_snapshot_has_text)
+  ' >/dev/null
+}
+
+jsonl_has_explicit_failure() {
+  echo "$1" | jq -e -s '
+    (
+      first(.[] | select(.record_type == "terminal")).stream_status == "interrupted"
+      and (
+        (first(.[] | select(.record_type == "terminal")).stream_error // "") | length
+      ) > 0
+    )
+    or any(.[]; .record_type == "event" and .event_type == "response.error")
+  ' >/dev/null
+}
+
+jsonl_has_reasoning_events() {
+  echo "$1" | jq -e -s '
+    any(
+      .[];
+      .record_type == "event"
+      and (
+        .event_type == "response.reasoning_summary_text.delta"
+        or .event_type == "response.reasoning_text.delta"
+      )
+    )
+  ' >/dev/null
+}
+
+jsonl_has_tool_argument_deltas() {
+  echo "$1" | jq -e -s '
+    any(
+      .[];
+      .record_type == "event"
+      and .event_type == "response.function_call_arguments.delta"
+    )
+  ' >/dev/null
+}
 
 # Run `flow run` with retries for transient readiness states.
 run_flow_retry() {
@@ -53,7 +120,8 @@ run_flow_retry() {
 run_otto_retry() {
   local workspace_title="$1"
   local model_id="$2"
-  local provider_id="${3:-}"
+  local prompt="$3"
+  local provider_id="${4:-}"
 
   local out=""
   local rc=1
@@ -65,9 +133,9 @@ run_otto_retry() {
 
     set +e
     if [ -n "$provider_id" ]; then
-      out=$($CLI otto run "ping" --workspace "$workspace_title" --provider "$provider_id" --model "$model_id" --thinking medium --jsonl 2>&1)
+      out=$($CLI otto run "$prompt" --workspace "$workspace_title" --provider "$provider_id" --model "$model_id" --thinking medium --jsonl 2>&1)
     else
-      out=$($CLI otto run "ping" --workspace "$workspace_title" --model "$model_id" --thinking medium --jsonl 2>&1)
+      out=$($CLI otto run "$prompt" --workspace "$workspace_title" --model "$model_id" --thinking medium --jsonl 2>&1)
     fi
     rc=$?
     set -e
@@ -264,29 +332,52 @@ else
 
     if [ -n "$FOUNDRY_GPT54_MODEL" ]; then
       set +e
-      FOUNDRY_OTTO_OUT=$(run_otto_retry "$RUNTIME_TITLE" "$FOUNDRY_GPT54_MODEL" "microsoft_foundry")
-      FOUNDRY_OTTO_RC=$?
+      FOUNDRY_SIMPLE_OUT=$(run_otto_retry "$RUNTIME_TITLE" "$FOUNDRY_GPT54_MODEL" "$FOUNDRY_SIMPLE_PROMPT" "microsoft_foundry")
+      FOUNDRY_SIMPLE_RC=$?
       set -e
 
-      if [ "$FOUNDRY_OTTO_RC" -ne 0 ]; then
-        fail "otto run foundry gpt-5.4 --thinking" "$FOUNDRY_OTTO_OUT"
+      if [ "$FOUNDRY_SIMPLE_RC" -ne 0 ]; then
+        fail "foundry gpt-5.4 simple prompt" "$FOUNDRY_SIMPLE_OUT"
       else
-        if echo "$FOUNDRY_OTTO_OUT" | jq -e 'select(.record_type == "request") | .provider == "microsoft_foundry" and .model == "azure_ai/gpt-5.4"' >/dev/null; then
-          pass "foundry gpt-5.4 probe preserved provider/model provenance"
+        if echo "$FOUNDRY_SIMPLE_OUT" | jq -e 'select(.record_type == "request") | .provider == "microsoft_foundry" and .model == "azure_ai/gpt-5.4"' >/dev/null; then
+          pass "foundry gpt-5.4 simple prompt preserved provider/model provenance"
         else
-          fail "foundry gpt-5.4 probe" "missing exact provider/model provenance"
+          fail "foundry gpt-5.4 simple prompt" "missing exact provider/model provenance"
         fi
 
-        if echo "$FOUNDRY_OTTO_OUT" | jq -e 'select(.record_type == "terminal") | .stream_status == "completed"' >/dev/null; then
-          pass "foundry gpt-5.4 probe emitted completed terminal record"
+        if jsonl_completed_with_output "$FOUNDRY_SIMPLE_OUT"; then
+          pass "foundry gpt-5.4 simple prompt returned assistant output"
+        elif jsonl_has_explicit_failure "$FOUNDRY_SIMPLE_OUT"; then
+          pass "foundry gpt-5.4 simple prompt surfaced an explicit failure"
         else
-          fail "foundry gpt-5.4 probe" "missing completed terminal record"
+          fail "foundry gpt-5.4 simple prompt" "missing assistant output and explicit surfaced failure"
         fi
+      fi
 
-        if echo "$FOUNDRY_OTTO_OUT" | jq -e 'select(.record_type == "event") | (.event_type == "response.reasoning_summary_text.delta" or .event_type == "response.reasoning_text.delta")' >/dev/null; then
-          pass "foundry gpt-5.4 probe surfaced reasoning events"
+      set +e
+      FOUNDRY_TOOL_OUT=$(run_otto_retry "$RUNTIME_TITLE" "$FOUNDRY_GPT54_MODEL" "$OTTO_TOOL_PROMPT" "microsoft_foundry")
+      FOUNDRY_TOOL_RC=$?
+      set -e
+
+      if [ "$FOUNDRY_TOOL_RC" -ne 0 ]; then
+        fail "foundry gpt-5.4 tool prompt" "$FOUNDRY_TOOL_OUT"
+      else
+        if jsonl_completed_with_output "$FOUNDRY_TOOL_OUT"; then
+          pass "foundry gpt-5.4 tool prompt returned assistant output"
+          if jsonl_has_reasoning_events "$FOUNDRY_TOOL_OUT"; then
+            pass "foundry gpt-5.4 tool prompt surfaced reasoning events"
+          else
+            fail "foundry gpt-5.4 tool prompt" "missing reasoning events on successful tool prompt"
+          fi
+          if jsonl_has_tool_argument_deltas "$FOUNDRY_TOOL_OUT"; then
+            pass "foundry gpt-5.4 tool prompt surfaced tool argument deltas"
+          else
+            fail "foundry gpt-5.4 tool prompt" "missing tool argument deltas on successful tool prompt"
+          fi
+        elif jsonl_has_explicit_failure "$FOUNDRY_TOOL_OUT"; then
+          pass "foundry gpt-5.4 tool prompt surfaced an explicit failure"
         else
-          skip "foundry gpt-5.4 probe emitted no reasoning events"
+          fail "foundry gpt-5.4 tool prompt" "missing assistant output and explicit surfaced failure"
         fi
       fi
     else
@@ -294,7 +385,7 @@ else
     fi
 
     set +e
-    OTTO_RUN_OUT=$(run_otto_retry "$RUNTIME_TITLE" "$OTTO_MODEL")
+    OTTO_RUN_OUT=$(run_otto_retry "$RUNTIME_TITLE" "$OTTO_MODEL" "$OTTO_TOOL_PROMPT")
     OTTO_RUN_RC=$?
     set -e
 
@@ -313,22 +404,22 @@ else
         fail "otto run --jsonl" "missing event records"
       fi
 
-      if echo "$OTTO_RUN_OUT" | jq -e 'select(.record_type == "terminal") | .stream_status == "completed"' >/dev/null; then
-        pass "otto run --jsonl emitted completed terminal record"
+      if jsonl_completed_with_output "$OTTO_RUN_OUT"; then
+        pass "otto run --jsonl emitted completed output"
       else
-        fail "otto run --jsonl" "missing completed terminal record"
+        fail "otto run --jsonl" "missing completed assistant output"
       fi
 
-      if echo "$OTTO_RUN_OUT" | jq -e 'select(.record_type == "event") | (.event_type == "response.reasoning_summary_text.delta" or .event_type == "response.reasoning_text.delta")' >/dev/null; then
-        pass "otto run --jsonl surfaced reasoning events"
+      if jsonl_has_reasoning_events "$OTTO_RUN_OUT"; then
+        pass "otto run --jsonl surfaced reasoning events for the tool-use prompt"
       else
-        skip "otto run --jsonl emitted no reasoning events for chosen model/prompt"
+        fail "otto run --jsonl" "missing reasoning events for the required tool-use prompt"
       fi
 
-      if echo "$OTTO_RUN_OUT" | jq -e 'select(.record_type == "event") | .event_type == "response.function_call_arguments.delta"' >/dev/null; then
-        pass "otto run --jsonl surfaced tool argument deltas"
+      if jsonl_has_tool_argument_deltas "$OTTO_RUN_OUT"; then
+        pass "otto run --jsonl surfaced tool argument deltas for the tool-use prompt"
       else
-        skip "otto run --jsonl emitted no tool argument deltas for chosen prompt"
+        fail "otto run --jsonl" "missing tool argument deltas for the required tool-use prompt"
       fi
     fi
   fi

--- a/tests/rest.js
+++ b/tests/rest.js
@@ -367,6 +367,9 @@ function pickReasoningOttoModel(providers) {
   return null;
 }
 
+const OTTO_TOOL_PROMPT =
+  "Use a tool to inspect the current workspace root, confirm whether the repo contains both ascend-tools and ascend-backend, and answer in two short sentences with the names you found.";
+
 function parseSseFrame(rawFrame) {
   const lines = rawFrame.split(/\r?\n/);
   let event = "message";
@@ -390,6 +393,12 @@ function parseSseFrame(rawFrame) {
     parsed = data;
   }
   return { event, data: parsed };
+}
+
+function findSseFrameBoundary(buffer) {
+  const match = buffer.match(/\r\n\r\n|\n\n|\r\r/);
+  if (!match || match.index == null) return null;
+  return { index: match.index, length: match[0].length };
 }
 
 async function readSseEvents(resp, { timeoutMs = 20000 } = {}) {
@@ -420,10 +429,10 @@ async function readSseEvents(resp, { timeoutMs = 20000 } = {}) {
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
 
-      let frameEnd = buffer.indexOf("\n\n");
-      while (frameEnd !== -1) {
-        const rawFrame = buffer.slice(0, frameEnd);
-        buffer = buffer.slice(frameEnd + 2);
+      let boundary = findSseFrameBoundary(buffer);
+      while (boundary) {
+        const rawFrame = buffer.slice(0, boundary.index);
+        buffer = buffer.slice(boundary.index + boundary.length);
         const parsed = parseSseFrame(rawFrame);
         if (parsed) {
           events.push(parsed);
@@ -436,7 +445,7 @@ async function readSseEvents(resp, { timeoutMs = 20000 } = {}) {
             return events;
           }
         }
-        frameEnd = buffer.indexOf("\n\n");
+        boundary = findSseFrameBoundary(buffer);
       }
     }
   } finally {
@@ -646,8 +655,7 @@ async function main() {
       } else {
         console.log(`  using otto model: ${ottoModel}`);
         const thread = await createOttoThreadWithRetry(client, runtimeUuid, {
-          prompt:
-            "Briefly explain what ASCEND_INSTANCE_API_URL is used for in one sentence.",
+          prompt: OTTO_TOOL_PROMPT,
           model: ottoModel,
           thinking: "medium",
         });
@@ -688,26 +696,16 @@ async function main() {
           "otto SSE reached a terminal event",
           JSON.stringify(eventTypes),
         );
-
-        if (reasoningDeltas.length > 0) {
-          check(
-            true,
-            `otto SSE surfaced ${reasoningDeltas.length} reasoning delta event(s)`,
-          );
-        } else {
-          skip("otto SSE emitted no reasoning deltas for the chosen model/prompt");
-        }
-
-        if (toolArgDeltas.length > 0) {
-          check(
-            true,
-            `otto SSE surfaced ${toolArgDeltas.length} function_call_arguments delta event(s)`,
-          );
-        } else {
-          skip(
-            "otto SSE emitted no function_call_arguments deltas for the chosen prompt",
-          );
-        }
+        check(
+          reasoningDeltas.length > 0,
+          "otto SSE surfaced reasoning deltas for the required tool-use prompt",
+          JSON.stringify(eventTypes),
+        );
+        check(
+          toolArgDeltas.length > 0,
+          "otto SSE surfaced function_call_arguments deltas for the required tool-use prompt",
+          JSON.stringify(eventTypes),
+        );
       }
     }
   } catch (e) {

--- a/tests/rest.js
+++ b/tests/rest.js
@@ -259,6 +259,34 @@ class AscendClient {
       runtime_uuid: runtimeUuid,
     });
   }
+
+  // -- Otto --
+
+  async listOttoProviders() {
+    return this._get("/api/v1/otto/providers");
+  }
+
+  async createOttoThread({ prompt, runtimeUuid, model, thinking } = {}) {
+    const body = { prompt };
+    if (runtimeUuid != null) body.runtime_uuid = runtimeUuid;
+    if (model != null) body.model = model;
+    if (thinking != null) body.thinking = thinking;
+    return this._postJson("/api/v1/otto/threads", body);
+  }
+
+  async openOttoUpdates(threadId) {
+    const resp = await fetch(
+      `${this.baseUrl}/api/v1/otto/threads/${encode(threadId)}/updates`,
+      {
+        headers: {
+          ...(await this._headers()),
+          Accept: "text/event-stream",
+        },
+      },
+    );
+    if (!resp.ok) await raiseForApiError(resp);
+    return resp;
+  }
 }
 
 /** Percent-encode a URL path segment. */
@@ -272,7 +300,13 @@ async function raiseForApiError(resp) {
   let detail = await resp.text();
   try {
     const json = JSON.parse(detail);
-    if (json.detail) detail = json.detail;
+    if (json.detail) {
+      detail =
+        typeof json.detail === "string" ? json.detail : JSON.stringify(json.detail);
+    } else if (json.error) {
+      detail =
+        typeof json.error === "string" ? json.error : JSON.stringify(json.error);
+    }
   } catch {
     // keep raw text
   }
@@ -322,6 +356,96 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function pickReasoningOttoModel(providers) {
+  for (const provider of providers) {
+    for (const model of provider.models ?? []) {
+      if (/(claude|gpt-5|o\d|gemini)/i.test(model.id)) {
+        return model.id;
+      }
+    }
+  }
+  return null;
+}
+
+function parseSseFrame(rawFrame) {
+  const lines = rawFrame.split(/\r?\n/);
+  let event = "message";
+  const dataLines = [];
+  for (const line of lines) {
+    if (!line || line.startsWith(":")) continue;
+    if (line.startsWith("event:")) {
+      event = line.slice("event:".length).trim();
+      continue;
+    }
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).trimStart());
+    }
+  }
+  if (dataLines.length === 0) return null;
+  const data = dataLines.join("\n");
+  let parsed;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    parsed = data;
+  }
+  return { event, data: parsed };
+}
+
+async function readSseEvents(resp, { timeoutMs = 20000 } = {}) {
+  if (!resp.body) throw new Error("SSE response has no body");
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  const events = [];
+  let buffer = "";
+
+  const readChunk = () =>
+    Promise.race([
+      reader.read(),
+      new Promise((_, reject) =>
+        setTimeout(
+          () =>
+            reject(
+              new Error(`timed out waiting for SSE chunk after ${timeoutMs}ms`),
+            ),
+          timeoutMs,
+        ),
+      ),
+    ]);
+
+  try {
+    for (;;) {
+      const { value, done } = await readChunk();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let frameEnd = buffer.indexOf("\n\n");
+      while (frameEnd !== -1) {
+        const rawFrame = buffer.slice(0, frameEnd);
+        buffer = buffer.slice(frameEnd + 2);
+        const parsed = parseSseFrame(rawFrame);
+        if (parsed) {
+          events.push(parsed);
+          if (
+            parsed.event === "thread.done" ||
+            parsed.event === "thread.stopped" ||
+            parsed.event === "response.error"
+          ) {
+            await reader.cancel().catch(() => {});
+            return events;
+          }
+        }
+        frameEnd = buffer.indexOf("\n\n");
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+
+  return events;
+}
+
 /**
  * Run a flow with retries for transient readiness states.
  */
@@ -345,6 +469,42 @@ async function runFlowWithRetry(client, runtimeUuid, flowName, opts = {}) {
     }
   }
   throw lastError ?? new Error("runFlow retry exhausted");
+}
+
+async function createOttoThreadWithRetry(
+  client,
+  runtimeUuid,
+  { prompt, model, thinking },
+) {
+  let lastError;
+  for (const delay of [0, 2, 5, 10, 15]) {
+    if (delay) await sleep(delay * 1000);
+    try {
+      return await client.createOttoThread({
+        prompt,
+        runtimeUuid,
+        model,
+        thinking,
+      });
+    } catch (e) {
+      const msg = String(e.message || e).toLowerCase();
+      if (msg.includes("paused")) {
+        await client.resumeRuntime(runtimeUuid);
+        lastError = e;
+        continue;
+      }
+      if (
+        msg.includes("starting") ||
+        msg.includes("no health status") ||
+        msg.includes("initializing")
+      ) {
+        lastError = e;
+        continue;
+      }
+      throw e;
+    }
+  }
+  throw lastError ?? new Error("createOttoThread retry exhausted");
 }
 
 // ---------------------------------------------------------------------------
@@ -461,6 +621,107 @@ async function main() {
     byKind.every((r) => r.kind === kind),
     "all results match kind filter",
   );
+
+  // ---------- otto streaming ----------
+
+  console.log("=== otto streaming ===");
+
+  try {
+    if (isPaused) {
+      const resumed = await client.resumeRuntime(runtimeUuid);
+      check(
+        resumed.paused === false,
+        "resumeRuntime clears paused before otto probe",
+      );
+    }
+    const ottoProviders = await client.listOttoProviders();
+    check(Array.isArray(ottoProviders), "listOttoProviders returns array");
+
+    if (!ottoProviders.length) {
+      skip("no otto providers configured — skipping otto streaming probe");
+    } else {
+      const ottoModel = pickReasoningOttoModel(ottoProviders);
+      if (!ottoModel) {
+        skip("no reasoning-capable otto model found for streaming probe");
+      } else {
+        console.log(`  using otto model: ${ottoModel}`);
+        const thread = await createOttoThreadWithRetry(client, runtimeUuid, {
+          prompt:
+            "Briefly explain what ASCEND_INSTANCE_API_URL is used for in one sentence.",
+          model: ottoModel,
+          thinking: "medium",
+        });
+        check(
+          typeof thread === "object" && thread.thread_id,
+          `createOttoThread returned thread_id: ${thread.thread_id}`,
+        );
+
+        const updates = await client.openOttoUpdates(thread.thread_id);
+        const events = await readSseEvents(updates);
+        const eventTypes = events.map((event) => event.event);
+        const textDeltas = events.filter(
+          (event) => event.event === "response.output_text.delta",
+        );
+        const reasoningDeltas = events.filter((event) =>
+          [
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_text.delta",
+          ].includes(event.event),
+        );
+        const toolArgDeltas = events.filter(
+          (event) => event.event === "response.function_call_arguments.delta",
+        );
+        const terminalEvent = events.find((event) =>
+          ["thread.done", "thread.stopped", "response.error"].includes(
+            event.event,
+          ),
+        );
+
+        check(events.length > 0, "otto SSE returned events");
+        check(
+          textDeltas.length > 0,
+          "otto SSE included text deltas",
+          JSON.stringify(eventTypes),
+        );
+        check(
+          Boolean(terminalEvent),
+          "otto SSE reached a terminal event",
+          JSON.stringify(eventTypes),
+        );
+
+        if (reasoningDeltas.length > 0) {
+          check(
+            true,
+            `otto SSE surfaced ${reasoningDeltas.length} reasoning delta event(s)`,
+          );
+        } else {
+          skip("otto SSE emitted no reasoning deltas for the chosen model/prompt");
+        }
+
+        if (toolArgDeltas.length > 0) {
+          check(
+            true,
+            `otto SSE surfaced ${toolArgDeltas.length} function_call_arguments delta event(s)`,
+          );
+        } else {
+          skip(
+            "otto SSE emitted no function_call_arguments deltas for the chosen prompt",
+          );
+        }
+      }
+    }
+  } catch (e) {
+    const msg = String(e.message || e).toLowerCase();
+    if (
+      msg.includes("not found") ||
+      msg.includes("not implemented") ||
+      msg.includes("404")
+    ) {
+      skip(`otto streaming not available: ${e.message || e}`);
+    } else {
+      check(false, "otto streaming probe", e.message || String(e));
+    }
+  }
 
   // ---------- flows ----------
 


### PR DESCRIPTION
Refs: https://github.com/ascend-io/ascend-backend/pull/1262
Refs: https://github.com/ascend-io/ascend-ui/pull/2236

## Why This Change
Otto's rollout needs a text-native client and proof surface that matches the instance-backed contract reviewers will see in the backend and UI PRs. This branch keeps `ascend-tools` aligned with the richer streaming and thread model plus the new instance-owned provider-settings route, so engineers can verify real CLI behavior without relying on cloud current-instance discovery. That makes the live `ascend-tools` proofs trustworthy for both operator workflows and companion-repo review.

## What Changed
- Extends the Otto CLI and core client so `otto run --jsonl` covers richer stream terminals, request provenance, and preserved follow-up thread IDs on same-thread runs.
- Keeps the JS, MCP, Python, and TUI bindings aligned with the evolved Otto client surface instead of leaving non-CLI consumers behind.
- Adds provider-list enrichment in `ascend-tools-core` so `ascend-tools -o json otto provider list` merges per-model `thinking_levels` from `/api/v1/otto/provider_settings`, with a graceful fallback to the legacy providers route when that endpoint is unavailable.
- Expands CLI/core/integration coverage to prove thread reuse, ordered JSONL output, and provider metadata parity across the repo's text-native validation paths.
- Refreshes CLI and validation-surface docs so reviewers can map this repo's operator-facing role to the companion backend/UI rollout.

## Example
Representative `ascend-tools -o json otto provider list` output now includes per-model `thinking_levels` when the instance backend publishes them:

```json
[
  {
    "id": "microsoft_foundry",
    "default_model": "azure_ai/gpt-5.4",
    "models": [
      {
        "id": "azure_ai/gpt-5.4",
        "thinking_levels": ["none", "minimal", "low", "medium", "high", "xhigh"]
      }
    ]
  }
]
```

## Changes Table
| Category | Files | Added | Deleted |
|---|---|---:|---:|
| Production - CLI | `crates/ascend-tools-cli/src/otto.rs` | 202 | 7 |
| Production - Core client & models | `crates/ascend-tools-core/src/client.rs`, `crates/ascend-tools-core/src/models.rs` | 324 | 122 |
| Production - Bindings | `crates/ascend-tools-js/src/lib.rs`, `crates/ascend-tools-mcp/src/server.rs`, `crates/ascend-tools-py/src/lib.rs`, `crates/ascend-tools-tui/src/lib.rs` | 13 | 5 |
| Tests | `crates/ascend-tools-cli/tests/cli_integration.rs`, `crates/ascend-tools-core/tests/client_http.rs`, `tests/integration.py`, `tests/integration.sh`, `tests/rest.js` | 1715 | 16 |
| Docs | `crates/ascend-tools-cli/src/skill-cli.md`, `docs/README.md`, `docs/cli.md`, `docs/exec-plans/**` | 442 | 0 |
| Dependencies | `crates/ascend-tools-js/package-lock.json`, `tests/app/package-lock.json` | 3 | 3 |
| **Total** | **25 files** | **2699** | **153** |

## Companion Context
- https://github.com/ascend-io/ascend-backend/pull/1262 publishes the instance-owned provider-settings contract and the streaming/runtime behavior this repo validates.
- https://github.com/ascend-io/ascend-ui/pull/2236 consumes the same provider-settings route in the browser.
- Review together for the full rollout story. The provider-list enrichment here degrades gracefully against older backends by falling back when `/api/v1/otto/provider_settings` is unavailable.

## Review Guide
- Start with `crates/ascend-tools-cli/src/otto.rs`, `crates/ascend-tools-core/src/client.rs`, and `crates/ascend-tools-core/src/models.rs` for the CLI/client contract, especially JSONL stream records and provider-settings enrichment.
- Use `crates/ascend-tools-core/tests/client_http.rs` and `crates/ascend-tools-cli/tests/cli_integration.rs` as the highest-signal proof for follow-up thread reuse, provider metadata merging, and terminal stream classification.
- Then read `tests/integration.sh`, `tests/integration.py`, and `tests/rest.js` as the live and text-native harness layer that mirrors how engineers validate Otto without the browser.
- Pay extra attention to the fallback behavior in `list_otto_providers()`: the new thinking-level metadata should enrich newer backends without regressing plain provider lists against older deployments.

## Validation
- `bin/check`
- Inside that matrix: Rust fmt, clippy, full Rust tests, ruff, ty, JS build, and JS tests all passed on the current `sean/ws-OttoMoarStreaming` head.
- Approved-instance read-only proof for this branch: `ASCEND_INSTANCE_API_URL="https://OttoMoarStreaming-instance.api.local.ascend.dev" uv run --project ascend-tools ascend-tools -o json otto provider list` surfaced per-model `thinking_levels`, and the text `otto provider list` output remained intact.
- Approved-instance same-thread proof for this branch: `ASCEND_INSTANCE_API_URL="https://OttoMoarStreaming-instance.api.local.ascend.dev" uv run --project ascend-tools ascend-tools otto run ... --jsonl` preserved `request_thread_id` and terminal `thread_id` across a follow-up turn.
