### PR TITLE
feat: add --query-policy flag for Otto headless mode

### DIFF
--- a/crates/ascend-tools-cli/src/otto.rs
+++ b/crates/ascend-tools-cli/src/otto.rs
@@ -196,6 +196,10 @@ pub(crate) enum OttoCommands {
         /// Resume the most recent conversation
         #[arg(long, conflicts_with_all = ["thread", "conversation"])]
         resume: bool,
+
+        /// Query execution policy: safe (default), unsafe, strict
+        #[arg(long, value_parser = ["safe", "unsafe", "strict"])]
+        query_policy: Option<String>,
     },
     /// Manage Otto providers
     Provider {
@@ -247,6 +251,10 @@ pub(crate) enum OttoCommands {
         /// Resume the most recent conversation
         #[arg(long, conflicts_with = "conversation")]
         resume: bool,
+
+        /// Query execution policy: safe (default), unsafe, strict
+        #[arg(long, value_parser = ["safe", "unsafe", "strict"])]
+        query_policy: Option<String>,
     },
 }
 
@@ -285,6 +293,7 @@ pub(crate) fn handle_otto_cmd(
             thread,
             conversation,
             resume,
+            query_policy,
         } => {
             let runtime_uuid = client.resolve_optional_runtime_target(
                 workspace.as_deref(),
@@ -304,6 +313,7 @@ pub(crate) fn handle_otto_cmd(
                 runtime_uuid,
                 thread_id,
                 model: client.resolve_otto_model(provider.as_deref(), model.as_deref())?,
+                query_policy,
             };
 
             match output {
@@ -434,6 +444,7 @@ pub(crate) fn handle_otto_cmd(
             model,
             conversation,
             resume,
+            query_policy,
         } => {
             let runtime_uuid = client.resolve_optional_runtime_target(
                 workspace.as_deref(),
@@ -447,7 +458,7 @@ pub(crate) fn handle_otto_cmd(
                 .or(deployment.as_deref().map(|d| format!("deployment:{d}")));
             let thread_id =
                 crate::conversation::resolve_conversation_flag(client, None, conversation, resume)?;
-            ascend_tools_tui::run_tui(client, runtime_uuid, otto_model, context_label, thread_id)
+            ascend_tools_tui::run_tui(client, runtime_uuid, otto_model, context_label, thread_id, query_policy)
         }
     }
 }

--- a/crates/ascend-tools-cli/src/otto.rs
+++ b/crates/ascend-tools-cli/src/otto.rs
@@ -458,7 +458,14 @@ pub(crate) fn handle_otto_cmd(
                 .or(deployment.as_deref().map(|d| format!("deployment:{d}")));
             let thread_id =
                 crate::conversation::resolve_conversation_flag(client, None, conversation, resume)?;
-            ascend_tools_tui::run_tui(client, runtime_uuid, otto_model, context_label, thread_id, query_policy)
+            ascend_tools_tui::run_tui(
+                client,
+                runtime_uuid,
+                otto_model,
+                context_label,
+                thread_id,
+                query_policy,
+            )
         }
     }
 }

--- a/crates/ascend-tools-core/src/models.rs
+++ b/crates/ascend-tools-core/src/models.rs
@@ -267,6 +267,11 @@ pub struct OttoChatRequest {
     pub thread_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<OttoModel>,
+    /// Query execution policy for headless sessions.
+    /// "safe" (default): auto-runs read-only queries, rejects writes.
+    /// "unsafe": auto-approves all queries. "strict": rejects all queries.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query_policy: Option<String>,
 }
 
 /// Terminal status for an Otto stream.

--- a/crates/ascend-tools-core/tests/client_http.rs
+++ b/crates/ascend-tools-core/tests/client_http.rs
@@ -417,6 +417,7 @@ fn otto_streaming_interrupted_when_sse_closes_without_terminal_event() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let mut observed_thread_id = None;
@@ -490,6 +491,7 @@ fn otto_streaming_completes_on_thread_done() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let mut text = String::new();
@@ -551,6 +553,7 @@ fn otto_streaming_completes_on_thread_stopped() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let mut text = String::new();
@@ -613,6 +616,7 @@ fn otto_streaming_cancelled_by_callback() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let mut delta_count = 0;
@@ -678,6 +682,7 @@ fn otto_streaming_handles_response_error_event() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let mut text = String::new();
@@ -751,6 +756,7 @@ fn otto_streaming_dispatches_tool_call_events() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let mut events_log: Vec<String> = Vec::new();
@@ -827,6 +833,7 @@ fn otto_streaming_skips_heartbeats_and_comments() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let mut text = String::new();
@@ -882,6 +889,7 @@ fn otto_streaming_sse_endpoint_returns_error() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let result = client.otto_streaming(&request, |_| ControlFlow::Continue(()), |_| {});
@@ -922,6 +930,7 @@ fn otto_streaming_thread_post_returns_error() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let result = client.otto_streaming(&request, |_| ControlFlow::Continue(()), |_| {});
@@ -968,6 +977,7 @@ fn otto_non_streaming_errors_on_interrupted_stream() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     // otto() (non-streaming) should return an error for interrupted streams
@@ -1028,6 +1038,7 @@ fn otto_streaming_retries_409_on_follow_up() {
         runtime_uuid: None,
         thread_id: Some("t-existing".into()),
         model: None,
+        query_policy: None,
     };
 
     let mut text = String::new();
@@ -1075,6 +1086,7 @@ fn otto_streaming_409_on_new_thread_returns_error() {
         runtime_uuid: None,
         thread_id: None, // new thread — no retry
         model: None,
+        query_policy: None,
     };
 
     let result = client.otto_streaming(&request, |_| ControlFlow::Continue(()), |_| {});
@@ -1124,6 +1136,7 @@ fn otto_streaming_on_thread_id_called_before_events() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let callback_order = std::sync::Mutex::new(Vec::<String>::new());
@@ -1185,6 +1198,7 @@ fn otto_streaming_empty_sse_stream_returns_interrupted() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let response = client
@@ -1222,6 +1236,7 @@ fn otto_streaming_missing_thread_id_in_response() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let result = client.otto_streaming(&request, |_| ControlFlow::Continue(()), |_| {});
@@ -1357,6 +1372,7 @@ fn otto_streaming_response_error_without_message() {
         runtime_uuid: None,
         thread_id: None,
         model: None,
+        query_policy: None,
     };
 
     let response = client

--- a/crates/ascend-tools-js/src/lib.rs
+++ b/crates/ascend-tools-js/src/lib.rs
@@ -376,7 +376,7 @@ impl Client {
             let otto_model = client.resolve_otto_model(provider.as_deref(), model.as_deref()).map_err(to_napi_err)?;
             let runtime_uuid = client.resolve_optional_runtime_target(workspace.as_deref(), deployment.as_deref(), uuid.as_deref()).map_err(to_napi_err)?;
             let thread_id = client.resolve_otto_thread(conversation.as_deref(), thread_id).map_err(to_napi_err)?;
-            let request = models::OttoChatRequest { prompt, runtime_uuid, thread_id, model: otto_model };
+            let request = models::OttoChatRequest { prompt, runtime_uuid, thread_id, model: otto_model, query_policy: None };
             client.otto(&request).map_err(to_napi_err)
         }))
     }
@@ -389,7 +389,7 @@ impl Client {
             let otto_model = client.resolve_otto_model(provider.as_deref(), model.as_deref()).map_err(to_napi_err)?;
             let runtime_uuid = client.resolve_optional_runtime_target(workspace.as_deref(), deployment.as_deref(), uuid.as_deref()).map_err(to_napi_err)?;
             let thread_id = client.resolve_otto_thread(conversation.as_deref(), thread_id).map_err(to_napi_err)?;
-            let request = models::OttoChatRequest { prompt, runtime_uuid, thread_id, model: otto_model };
+            let request = models::OttoChatRequest { prompt, runtime_uuid, thread_id, model: otto_model, query_policy: None };
             client.otto_streaming(&request, |event| { if let models::StreamEvent::TextDelta(delta) = event { on_delta.call(Ok(delta), ThreadsafeFunctionCallMode::NonBlocking); } std::ops::ControlFlow::Continue(()) }, |_| {}).map_err(to_napi_err)
         }))
     }

--- a/crates/ascend-tools-mcp/src/server.rs
+++ b/crates/ascend-tools-mcp/src/server.rs
@@ -524,6 +524,7 @@ impl AscendMcpServer {
                 runtime_uuid,
                 thread_id,
                 model,
+                query_policy: None,
             })
         })
         .await

--- a/crates/ascend-tools-py/src/lib.rs
+++ b/crates/ascend-tools-py/src/lib.rs
@@ -531,6 +531,7 @@ impl Client {
                     runtime_uuid,
                     thread_id,
                     model: otto_model,
+                    query_policy: None,
                 };
                 self.inner.otto(&request)
             })

--- a/crates/ascend-tools-tui/src/lib.rs
+++ b/crates/ascend-tools-tui/src/lib.rs
@@ -318,6 +318,7 @@ struct App {
     provider_label: Option<String>,
     model_label: String,
     context_label: Option<String>,
+    query_policy: Option<String>,
     pending_request: Option<OttoChatRequest>,
     should_quit: bool,
     spinner_frame: usize,
@@ -348,6 +349,7 @@ impl App {
         model_label: String,
         context_label: Option<String>,
         thread_id: Option<String>,
+        query_policy: Option<String>,
     ) -> Self {
         Self {
             messages: Vec::new(),
@@ -367,6 +369,7 @@ impl App {
             provider_label,
             model_label,
             context_label,
+            query_policy,
             pending_request: None,
             should_quit: false,
             spinner_frame: 0,
@@ -823,6 +826,7 @@ impl App {
             runtime_uuid: self.runtime_uuid.clone(),
             thread_id: self.thread_id.clone(),
             model: self.otto_model.clone(),
+            query_policy: self.query_policy.clone(),
         });
         self.streaming = true;
         self.stream_buffer.clear();
@@ -2399,6 +2403,7 @@ pub fn run_tui(
     otto_model: Option<OttoModel>,
     context_label: Option<String>,
     thread_id: Option<String>,
+    query_policy: Option<String>,
 ) -> Result<()> {
     // Setup terminal
     terminal::enable_raw_mode()?;
@@ -2452,6 +2457,7 @@ pub fn run_tui(
             String::new(),
             context_label,
             thread_id.clone(),
+            query_policy,
         );
 
         // If resuming a conversation, load its history in the background
@@ -2653,7 +2659,7 @@ mod tests {
     use std::sync::atomic::AtomicU64;
 
     fn test_app() -> App {
-        App::new(None, None, None, String::new(), None, None)
+        App::new(None, None, None, String::new(), None, None, None)
     }
 
     // -- Stream lifecycle --------------------------------------------------

--- a/crates/ascend-tools-tui/src/lib.rs
+++ b/crates/ascend-tools-tui/src/lib.rs
@@ -3521,6 +3521,7 @@ mod tests {
             runtime_uuid: None,
             thread_id: None,
             model: None,
+            query_policy: None,
         });
 
         // The main loop guard is: if !app.interrupting && let Some(req) = app.take_pending_request()


### PR DESCRIPTION
closes https://github.com/ascend-io/ascend-tools/issues/47

## Summary

Adds a --query-policy CLI/TUI flag to support Otto headless execution mode, which controls how queries are handled when no human is in the loop.

- Adds query_policy field to OttoChatRequest in the core model (Option<String>, skipped when None for backwards compatibility)
- Adds --query-policy arg to both otto chat and otto tui CLI subcommands with validation restricted to safe, unsafe, strict
- Threads query_policy through the TUI App state so it is included on every request in a session
- Sets query_policy: None in the MCP server (defaults to safe on the backend; MCP does not yet expose this parameter)

Policy values:
- **safe** (default): auto-runs read-only queries, rejects writes
- **unsafe**: auto-approves all queries including writes
- **strict**: rejects all queries

Companion to headless mode work in [ascend-backend](https://github.com/ascend-io/ascend-backend).